### PR TITLE
[B-03566] sync single project based on project name

### DIFF
--- a/app/config/apiMapping.js
+++ b/app/config/apiMapping.js
@@ -143,6 +143,11 @@ var apiMapping = {
             'endpoint': '/private/queue',
             'controller': 'project',
             'method': 'get-field-profile-labels'
+        },
+        syncDocuments: {
+            'endpoint': '/private/queue',
+            'controller': 'project',
+            'method': 'sync'
         }
     },
     ProjectRepository: {

--- a/app/controllers/adminController.js
+++ b/app/controllers/adminController.js
@@ -4,14 +4,4 @@ metadataTool.controller('AdminController', function ($controller, $injector, $ro
         $scope: $scope
     }));
 
-    $scope.sync = function () {
-        WsApi.fetch({
-            endpoint: '/private/queue',
-            controller: 'admin',
-            method: 'sync'
-        }).then(function (data) {
-            logger.log(data);
-        });
-    };
-
 });

--- a/app/controllers/projectController.js
+++ b/app/controllers/projectController.js
@@ -1,4 +1,4 @@
-metadataTool.controller('ProjectController', function ($controller, $scope, UserService, ProjectRepo, ProjectRepositoryRepo, ProjectAuthorityRepo, ProjectSuggestorRepo, MetadataRepo) {
+metadataTool.controller('ProjectController', function ($controller, $scope, AlertService, UserService, ProjectRepo, ProjectRepositoryRepo, ProjectAuthorityRepo, ProjectSuggestorRepo, MetadataRepo) {
 
     angular.extend(this, $controller('AbstractController', {$scope: $scope}));
 
@@ -17,6 +17,7 @@ metadataTool.controller('ProjectController', function ($controller, $scope, User
     $scope.inputTypes = [];
 
     $scope.isEditing = false;
+    $scope.isSyncing = false;
 
     $scope.displayResponse = {"status":null,"message":null};
 
@@ -155,6 +156,16 @@ metadataTool.controller('ProjectController', function ($controller, $scope, User
                 result = response;
             }
             return result;
+        };
+
+        $scope.syncDocuments = function (project) {
+            $scope.isSyncing = true;
+            ProjectRepo.syncDocuments(project.id).then(function (rawResponse) {
+                var response = angular.fromJson(rawResponse.body);
+                AlertService.add(response.meta, "app/projects");
+                $scope.closeModal();
+                $scope.isSyncing = false;
+            });
         };
     }
   });

--- a/app/controllers/projectController.js
+++ b/app/controllers/projectController.js
@@ -162,7 +162,9 @@ metadataTool.controller('ProjectController', function ($controller, $scope, Aler
             $scope.isSyncing = true;
             ProjectRepo.syncDocuments(project.id).then(function (rawResponse) {
                 var response = angular.fromJson(rawResponse.body);
-                AlertService.add(response.meta, "app/projects");
+                if (response.meta.status === "SUCCESS") {
+                  AlertService.add(response.meta, "app/projects");
+                }
                 $scope.closeModal();
                 $scope.isSyncing = false;
             });

--- a/app/index.html
+++ b/app/index.html
@@ -54,6 +54,7 @@
                 <modal modal-id="assumeUserModal" modal-view="node_modules/weaver-ui-core/app/views/modals/assumeUserModal.html" modal-header-class="modal-header-primary"></modal>
                 <modal modal-id="exportMetadataModal" modal-controller="ExportController" modal-view="views/modals/exportMetadataModal.html" modal-header-class="modal-header-primary"></modal>
                 <modal modal-id="batchPublishModal" modal-controller="BatchPublishController" modal-view="views/modals/batchPublishModal.html" modal-header-class="modal-header-primary"></modal>
+                <modal modal-id="syncDocumentsModal" modal-controller="ProjectController" modal-view="views/modals/syncDocumentsModal.html" modal-header-class="modal-header-primary"></modal>
               </div>
 
               <div class="dropdown">
@@ -78,7 +79,7 @@
                     <a href ng-if="isAssuming() == 'false'" data-toggle="modal" ng-click="openModal('#assumeUserModal')">{{assumedControl.button}}</a>
                     <a href ng-if="isAssuming() == 'true'" ng-click="assumeUser(assume)">{{assumedControl.button}}</a>
                   </li>
-                  <li><a ng-if="isAdmin()" ng-click="sync()" href="#">Sync Documents</a></li>
+                  <li><a ng-if="isAdmin()" ng-click="openModal('#syncDocumentsModal')" href="#">Sync Documents</a></li>
                 </ul>
               </div>
 

--- a/app/repo/projectRepo.js
+++ b/app/repo/projectRepo.js
@@ -44,6 +44,13 @@ metadataTool.repo("ProjectRepo", function ProjectRepo(WsApi) {
         return WsApi.fetch(this.mapping.getFieldProfileLabels);
     };
 
+    this.syncDocuments = function (projectId) {
+        angular.extend(this.mapping.syncDocuments, {
+            'method': 'sync/' + projectId
+        });
+        return WsApi.fetch(this.mapping.syncDocuments);
+    };
+
     return this;
 
 });

--- a/app/views/modals/syncDocumentsModal.html
+++ b/app/views/modals/syncDocumentsModal.html
@@ -1,0 +1,17 @@
+<div class="modal-header {{attr.modalHeaderClass}}">
+    <button type="button" class="close modal-close" aria-label="Close" ng-click="closeModal()"><span aria-hidden="true">&times;</span></button>
+    <h4 class="modal-title">Sync Documents</h4>
+</div>
+
+<form name="syncDocumentsModalForm">
+    <div class="modal-body">
+        <div class="form-group">
+            <label>Project</label>
+            <select ng-options="project.name for project in projects | orderBy: 'name'" ng-model="projectName" class="form-control"></select>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-default" ng-click="syncDocuments(projectName);" ng-disabled="isSyncing || !projectName"><span ng-if="isSyncing" class="glyphicon glyphicon-refresh spinning"></span> Sync Documents</button>
+        <button type="button" class="btn btn-default" ng-click="closeModal();">Cancel</button>
+    </div>
+</form>


### PR DESCRIPTION
Use apiMapping for the sync path.
Relocate sync functionality from adminController to projectController.
Implement project-specific sync using a modal popup, selecting project by name, and using a spinner.