### PR TITLE
Fix impossible user roles conditional

### DIFF
--- a/app/controllers/userRepoController.js
+++ b/app/controllers/userRepoController.js
@@ -6,78 +6,78 @@ metadataTool.controller('UserRepoController', function ($controller, $location, 
 
     UserService.userReady().then(function() {
 
-    $scope.assignableRoles = function(userRole) {
-        if($scope.isAdmin()) {
-            return ['ROLE_ADMIN','ROLE_MANAGER','ROLE_ANNOTATOR','ROLE_USER'];
-        }
-        else if($scope.isManager()) {
-            if(userRole == 'ROLE_ADMIN') {
-                return ['ROLE_ADMIN'];
+        $scope.assignableRoles = function(userRole) {
+            if($scope.isAdmin()) {
+                return ['ROLE_ADMIN','ROLE_MANAGER','ROLE_ANNOTATOR','ROLE_USER'];
             }
-            return ['ROLE_MANAGER','ROLE_ANNOTATOR','ROLE_USER'];
-        }
-        else {
-            return [userRole];
-        }
-    };
-
-    $scope.canDelete = function(user) {
-        var canDelete;
-        if($scope.isAdmin()) {
-            canDelete = true;
-        }
-        else if($scope.isManager()) {
-            if(user.role == "ROLE_ADMIN") {
-                canDelete = false;
+            else if($scope.isManager()) {
+                if(userRole == 'ROLE_ADMIN') {
+                    return ['ROLE_ADMIN'];
+                }
+                return ['ROLE_MANAGER','ROLE_ANNOTATOR','ROLE_USER'];
             }
             else {
+                return [userRole];
+            }
+        };
+
+        $scope.canDelete = function(user) {
+            var canDelete;
+            if($scope.isAdmin()) {
                 canDelete = true;
             }
-        }
-        else {
-            canDelete = false;
-        }
-        if(user.uin == $scope.user.uin) {
-            canDelete = false;
-        }
-        return canDelete;
-    };
-
-    if($scope.isAdmin() || $scope.isManager()) {
-
-        var UserRepo = $injector.get("UserRepo");
-
-        $scope.userUpdated = {};
-
-        $scope.users = UserRepo.getAll();
-
-        $scope.updateRole = function(user) {
-
-            angular.extend($scope.userUpdated, user);
-
-            user.save();
-
-            if($scope.user.username == user.username) {
-                if(user.role == 'ROLE_ANNOTATOR') {
-                    $location.path('/assignments');
+            else if($scope.isManager()) {
+                if(user.role == "ROLE_ADMIN") {
+                    canDelete = false;
                 }
-                else if(user.role == 'ROLE_USER') {
-                    $location.path('/myview');
+                else {
+                    canDelete = true;
                 }
-                else {}
             }
+            else {
+                canDelete = false;
+            }
+            if(user.uin == $scope.user.uin) {
+                canDelete = false;
+            }
+            return canDelete;
         };
 
-        $scope.delete = function(user) {
-            user.delete();
-        };
+        if($scope.isAdmin() || $scope.isManager()) {
 
-        UserRepo.listen(function(response) {
+            var UserRepo = $injector.get("UserRepo");
+
             $scope.userUpdated = {};
-            $route.reload();
-        });
 
-    }
+            $scope.users = UserRepo.getAll();
+
+            $scope.updateRole = function(user) {
+
+                angular.extend($scope.userUpdated, user);
+
+                user.save();
+
+                if($scope.user.username == user.username) {
+                    if(user.role == 'ROLE_ANNOTATOR') {
+                        $location.path('/assignments');
+                    }
+                    else if(user.role == 'ROLE_USER') {
+                        $location.path('/myview');
+                    }
+                    else {}
+                }
+            };
+
+            $scope.delete = function(user) {
+                user.delete();
+            };
+
+            UserRepo.listen(function(response) {
+                $scope.userUpdated = {};
+                $route.reload();
+            });
+
+        }
 
     });
 

--- a/app/controllers/userRepoController.js
+++ b/app/controllers/userRepoController.js
@@ -60,9 +60,6 @@ metadataTool.controller('UserRepoController', function ($controller, $location, 
                     canDelete = true;
                 }
             }
-            else {
-                canDelete = false;
-            }
             if(user.uin == $scope.user.uin) {
                 canDelete = false;
             }

--- a/app/controllers/userRepoController.js
+++ b/app/controllers/userRepoController.js
@@ -41,9 +41,6 @@ metadataTool.controller('UserRepoController', function ($controller, $location, 
                 }
                 return ['ROLE_MANAGER','ROLE_ANNOTATOR','ROLE_USER'];
             }
-            else {
-                return [userRole];
-            }
         };
 
         $scope.delete = function(user) {

--- a/app/controllers/userRepoController.js
+++ b/app/controllers/userRepoController.js
@@ -6,6 +6,43 @@ metadataTool.controller('UserRepoController', function ($controller, $location, 
 
     UserService.userReady().then(function() {
 
+    $scope.assignableRoles = function(userRole) {
+        if($scope.isAdmin()) {
+            return ['ROLE_ADMIN','ROLE_MANAGER','ROLE_ANNOTATOR','ROLE_USER'];
+        }
+        else if($scope.isManager()) {
+            if(userRole == 'ROLE_ADMIN') {
+                return ['ROLE_ADMIN'];
+            }
+            return ['ROLE_MANAGER','ROLE_ANNOTATOR','ROLE_USER'];
+        }
+        else {
+            return [userRole];
+        }
+    };
+
+    $scope.canDelete = function(user) {
+        var canDelete;
+        if($scope.isAdmin()) {
+            canDelete = true;
+        }
+        else if($scope.isManager()) {
+            if(user.role == "ROLE_ADMIN") {
+                canDelete = false;
+            }
+            else {
+                canDelete = true;
+            }
+        }
+        else {
+            canDelete = false;
+        }
+        if(user.uin == $scope.user.uin) {
+            canDelete = false;
+        }
+        return canDelete;
+    };
+
     if($scope.isAdmin() || $scope.isManager()) {
 
         var UserRepo = $injector.get("UserRepo");
@@ -31,39 +68,8 @@ metadataTool.controller('UserRepoController', function ($controller, $location, 
             }
         };
 
-        $scope.allowableRoles = function(userRole) {
-            if($scope.isAdmin()) {
-                return ['ROLE_ADMIN','ROLE_MANAGER','ROLE_ANNOTATOR','ROLE_USER'];
-            }
-            else if($scope.isManager()) {
-                if(userRole == 'ROLE_ADMIN') {
-                    return ['ROLE_ADMIN'];
-                }
-                return ['ROLE_MANAGER','ROLE_ANNOTATOR','ROLE_USER'];
-            }
-        };
-
         $scope.delete = function(user) {
             user.delete();
-        };
-
-        $scope.canDelete = function(user) {
-            var canDelete;
-            if($scope.isAdmin()) {
-                canDelete = true;
-            }
-            else if($scope.isManager()) {
-                if(user.role == "ROLE_ADMIN") {
-                    canDelete = false;
-                }
-                else {
-                    canDelete = true;
-                }
-            }
-            if(user.uin == $scope.user.uin) {
-                canDelete = false;
-            }
-            return canDelete;
         };
 
         UserRepo.listen(function(response) {

--- a/app/views/users.html
+++ b/app/views/users.html
@@ -30,7 +30,7 @@
                             <td>{{thisUser.role}}</td>
                             <td>
                                 <select ng-if="(isAdmin() || isManager())" ng-model="thisUser.role" ng-change="updateRole(thisUser)" class="form-control">
-                                    <option ng-repeat="role in allowableRoles(thisUser.role)">{{role}}</option>
+                                    <option ng-repeat="role in assignableRoles(thisUser.role)">{{role}}</option>
                                 </select>
                             </td>
                             <td ng-if="(isAdmin() || isManager()) && (thisUser.role == 'ROLE_ANNOTATOR' || thisUser.role == 'ROLE_MANAGER' || thisUser.role == 'ROLE_ADMIN')">


### PR DESCRIPTION
The allowableRoles() method only ever gets defined if either isAdmin() or isManager() is true.
The final else case will never trigger.

I believe this is another case for avoiding defining methods based on a users role.
A better approach may be to move the `allowableRoles` method outside of the isAdmin() and isManager() calls.
This will allow the method to both be called and to return something potentially valid.
Having said that, looking at the code, it does not make sense to me that if one asked for a role, they would simply get it.

I think that after reviewing the entire method, the `userRole` parameter may need to be removed, along with the conditional OR the conditional needs to be tested for first (given some assumption that an admin or a manager may explicitly define allowableRoles).

For now, this just removes the impossible case while preserving the remaining structure to hopefully avoid potential breakage.