### PR TITLE
Mispelled repository variable name exposes a repository to the global scope level

### DIFF
--- a/app/controllers/annotateController.js
+++ b/app/controllers/annotateController.js
@@ -211,7 +211,7 @@ metadataTool.controller('AnnotateController', function ($controller, $http, $loc
         };
 
         $scope.getRepositoryById = function(repositoryId) {
-            var respository = null;
+            var repository = null;
             for (var i in $scope.repositories) {
                 if (repositoryId == $scope.repositories[i].id) {
                     repository = $scope.repositories[i];


### PR DESCRIPTION
When getRepositoryById() is called with a correct id, subsequent calls using invalid/non-existent ids will (incorrectly) return the previous loaded repository.