### PR TITLE
Defect 01222: Assigned documents not showing when managing users

### DIFF
--- a/app/controllers/documentController.js
+++ b/app/controllers/documentController.js
@@ -84,7 +84,7 @@ metadataTool.controller('DocumentController', function ($controller, $location, 
                 return DocumentRepo.page(params.page(), params.count(), key, params.sorting()[key], filters).then(function (page) {
                     params.total(page.totalElements);
                     $location.search('page', params.page());
-                    return DocumentRepo.getAll();
+                    return angular.extend([], DocumentRepo.getAll());
                 });
             }
         });


### PR DESCRIPTION
ngTables is altering the documents array.
Prevent ngTables changes from affecting the documents array by passing it a copy of the documents array.