### PR TITLE
[D01288] Basic image viewer has large images overflow

### DIFF
--- a/app/resources/styles/sass/app.scss
+++ b/app/resources/styles/sass/app.scss
@@ -256,3 +256,13 @@ main footer {
 .openseadragon-container {
   min-height: 675px;
 }
+
+content-viewer {
+  .viewer-wrapper {
+    .image-wrapper {
+      height: 100%;
+      width: 100%;
+      overflow: auto;
+    }
+  }
+}

--- a/app/views/directives/viewers/imageViewer.html
+++ b/app/views/directives/viewers/imageViewer.html
@@ -1,8 +1,10 @@
 <nav aria-label="...">
-    <ul class="pager">
-        <li class="previous" ng-if="getFiles().length > 1" ng-class="{ 'disabled': current === 0}"><a class="toggle-href" ng-click="previous()">Previous</a></li>
-        <li class="title">{{getFiles()[current].name}}</li>
-        <li class="next" ng-if="getFiles().length > 1" ng-class="{ 'disabled': current === getFiles().length-1}"><a class="toggle-href" ng-click="next()">Next</a></li>
-    </ul>
+  <ul class="pager">
+    <li class="previous" ng-if="getFiles().length > 1" ng-class="{ 'disabled': current === 0}"><a class="toggle-href" ng-click="previous()">Previous</a></li>
+    <li class="title">{{getFiles()[current].name}}</li>
+    <li class="next" ng-if="getFiles().length > 1" ng-class="{ 'disabled': current === getFiles().length-1}"><a class="toggle-href" ng-click="next()">Next</a></li>
+  </ul>
 </nav>
-<img src="{{getFiles()[current].url}}" />
+<div class="image-wrapper">
+  <img src="{{getFiles()[current].url}}">
+</div>


### PR DESCRIPTION
A wrapper div is used to constrain overflow scroll bars to just the images.
This avoids adding scrolling to the `next` button, `prev` button, and image label.