### PR TITLE
[D01294]: Use custom property field 'publishing' to facilitate preventing re-publishing while pending publishing

### DIFF
--- a/app/resources/styles/sass/app.scss
+++ b/app/resources/styles/sass/app.scss
@@ -253,6 +253,12 @@ main footer {
   overflow-y:auto;
 }
 
+.panel-documentPublishing {
+  .panel-body {
+    min-height: 50px;
+  }
+}
+
 .openseadragon-container {
   min-height: 675px;
 }

--- a/app/resources/styles/sass/app.scss
+++ b/app/resources/styles/sass/app.scss
@@ -255,7 +255,7 @@ main footer {
 
 .panel-documentPublishing {
   .panel-body {
-    min-height: 50px;
+    min-height: 64px;
   }
 }
 

--- a/app/resources/styles/sass/app.scss
+++ b/app/resources/styles/sass/app.scss
@@ -253,7 +253,7 @@ main footer {
   overflow-y:auto;
 }
 
-.panel-documentPublishing {
+.panel-document-publishing {
   .panel-body {
     min-height: 64px;
   }

--- a/app/views/annotate.html
+++ b/app/views/annotate.html
@@ -25,10 +25,15 @@
             </div>
         </div>
     </div>
-    <div ng-if="action === 'view' && document.status === 'Accepted' && document.getProject().repositories.length > 0" class="panel panel-warning">
+    <div ng-if="action === 'view' && document.status === 'Accepted' && !document.publishing && document.getProject().repositories.length > 0" class="panel panel-warning panel-documentPublishing">
         <div class="panel-heading">This document is accepted but not published.</div>
         <div class="panel-body">
             <button class="btn btn-success" ng-click="push()">Publish</button>
+        </div>
+    </div>
+    <div ng-if="action === 'view' && document.status === 'Accepted' && document.publishing && document.getProject().repositories.length > 0" class="panel panel-warning panel-documentPublishing">
+        <div class="panel-heading">This document is pending publication.</div>
+        <div class="panel-body">
         </div>
     </div>
 

--- a/app/views/annotate.html
+++ b/app/views/annotate.html
@@ -25,13 +25,13 @@
             </div>
         </div>
     </div>
-    <div ng-if="action === 'view' && document.status === 'Accepted' && !document.publishing && document.getProject().repositories.length > 0" class="panel panel-warning panel-documentPublishing">
+    <div ng-if="action === 'view' && document.status === 'Accepted' && !document.publishing && document.getProject().repositories.length > 0" class="panel panel-warning panel-document-publishing">
         <div class="panel-heading">This document is accepted but not published.</div>
         <div class="panel-body">
             <button class="btn btn-success" ng-click="push()">Publish</button>
         </div>
     </div>
-    <div ng-if="action === 'view' && document.status === 'Accepted' && document.publishing && document.getProject().repositories.length > 0" class="panel panel-warning panel-documentPublishing">
+    <div ng-if="action === 'view' && document.status === 'Accepted' && document.publishing && document.getProject().repositories.length > 0" class="panel panel-warning panel-document-publishing">
         <div class="panel-heading">This document is pending publication.</div>
         <div class="panel-body">
         </div>

--- a/tests/core/mocks/mockAbstractCoreModel.js
+++ b/tests/core/mocks/mockAbstractCoreModel.js
@@ -11,8 +11,7 @@ var mockModel = function (modelName, $q, mockDataObj) {
             for (var i in keys) {
                 model[keys[i]] = toMock[keys[i]];
             }
-        }
-        else if (toMock === undefined || toMock === null) {
+        } else if (toMock === undefined || toMock === null) {
             model = null;
         }
     };
@@ -49,11 +48,11 @@ var mockModel = function (modelName, $q, mockDataObj) {
     };
 
     model.enableMergeCombinationOperation = function () {
-        combinationOperation = 'merge';
+        combinationOperation = "merge";
     };
 
     model.enableExtendCombinationOperation = function () {
-        combinationOperation = 'extend';
+        combinationOperation = "extend";
     };
 
     model.fetch = function() {
@@ -78,10 +77,19 @@ var mockModel = function (modelName, $q, mockDataObj) {
     model.listen = function() {
     };
 
+    model.ready = function() {
+        var defer = $q.defer();
+        defer.resolve();
+        return defer.promise;
+    };
+
     model.refresh = function() {
     };
 
     model.reload = function() {
+        var defer = $q.defer();
+        defer.resolve(model);
+        return defer.promise;
     };
 
     model.save = function() {

--- a/tests/core/mocks/mockAbstractCoreRepo.js
+++ b/tests/core/mocks/mockAbstractCoreRepo.js
@@ -100,6 +100,7 @@ var mockRepo = function (repoName, $q, mockModelCtor, mockDataArray) {
                 break;
             }
         }
+
         return payloadPromise($q.defer());
     };
 
@@ -110,6 +111,7 @@ var mockRepo = function (repoName, $q, mockModelCtor, mockDataArray) {
                 break;
             }
         }
+
         return payloadPromise($q.defer());
     };
 
@@ -128,6 +130,7 @@ var mockRepo = function (repoName, $q, mockModelCtor, mockDataArray) {
                 found = repo.mockCopy(repo.mockedList[i]);
             }
         }
+
         return found;
     };
 
@@ -167,23 +170,22 @@ var mockRepo = function (repoName, $q, mockModelCtor, mockDataArray) {
         if (typeof cbOrActionOrActionArray === "function") {
             var apiRes = {
                 meta: {
-                    status: 'SUCCESS',
+                    status: "SUCCESS",
                     message: ""
                 },
                 status: 200
             };
             cbOrActionOrActionArray(apiRes);
-        }
-        else if (Array.isArray(cbOrActionOrActionArray)) {
+        } else if (Array.isArray(cbOrActionOrActionArray)) {
             for (var cbAction in cbOrActionOrActionArray) {
                 if (typeof cbAction === "function") {
                     cbAction();
                 }
             }
-        }
-        else if (typeof cb === "function") {
+        } else if (typeof cb === "function") {
             cb();
         }
+
         return payloadPromise($q.defer());
     };
 
@@ -216,6 +218,7 @@ var mockRepo = function (repoName, $q, mockModelCtor, mockDataArray) {
         if (typeof modelToSave === "object") {
             var isNew = true;
             var savedModel = repo.mockModel(modelToSave);
+
             for (var i in repo.mockedList) {
                 if (repo.mockedList[i].id === modelToSave.id) {
                     angular.extend(repo.mockedList[i], savedModel);
@@ -263,6 +266,7 @@ var mockRepo = function (repoName, $q, mockModelCtor, mockDataArray) {
                 break;
             }
         }
+
         return payloadPromise($q.defer(), updated);
     };
 

--- a/tests/mocks/models/mockDocument.js
+++ b/tests/mocks/models/mockDocument.js
@@ -16,6 +16,7 @@ var dataDocument1 = {
     path: "",
     project: "Project 001",
     publishedLocations: [],
+    publishing: false,
     status: ""
 };
 
@@ -40,6 +41,7 @@ var dataDocument2 = {
     path: "",
     project: "Project 001",
     publishedLocations: [],
+    publishing: false,
     status: ""
 };
 
@@ -52,6 +54,7 @@ var dataDocument3 = {
     path: "",
     project: "Project 002",
     publishedLocations: [],
+    publishing: false,
     status: ""
 };
 
@@ -64,6 +67,7 @@ var dataDocument4 = {
     path: "",
     project: "Project 003",
     publishedLocations: [],
+    publishing: false,
     status: ""
 };
 
@@ -76,6 +80,7 @@ var dataDocument5 = {
     path: "",
     project: "Project 003",
     publishedLocations: [],
+    publishing: false,
     status: ""
 };
 
@@ -88,6 +93,7 @@ var dataDocument6 = {
     path: "",
     project: "Project 004",
     publishedLocations: [],
+    publishing: false,
     status: ""
 };
 


### PR DESCRIPTION
Utilize the `publishing` property now present on the document model.
When publishing is true, display a custom message.
Do not display the publish button while pending publication.

Update tests.

A min-height is provided for when publishing is true to match the width of the panel when there is a Publish button for the purposes of reducing flickering during fast publishing status changes.

relates: TAMULib/MetadataAssignmentToolService#229