### PR TITLE
[B03983] Broadcast last event to in-progress Publishing box - eliminate the spinner

### DIFF
--- a/app/config/apiMapping.js
+++ b/app/config/apiMapping.js
@@ -239,6 +239,11 @@ var apiMapping = {
             'method': 'types'
         }
     },
+    PublishingEvent: {
+      channel: '/channel/publishing',
+      lazy: true,
+      validations: false
+    },
     User: {
         channel: '/channel/user',
         instantiate: {

--- a/app/controllers/annotateController.js
+++ b/app/controllers/annotateController.js
@@ -1,4 +1,4 @@
-metadataTool.controller('AnnotateController', function ($controller, $location, $routeParams, $q, $scope, $timeout, AlertService, ControlledVocabularyRepo, DocumentRepo, ResourceRepo, StorageService, UserService, ProjectRepositoryRepo, ApiResponseActions, WsApi) {
+metadataTool.controller('AnnotateController', function ($controller, $location, $routeParams, $q, $scope, $timeout, AlertService, ControlledVocabularyRepo, DocumentRepo, ResourceRepo, StorageService, UserService, ProjectRepositoryRepo, PublishingEvent, ApiResponseActions, WsApi) {
 
     angular.extend(this, $controller('AbstractController', {
         $scope: $scope
@@ -239,16 +239,16 @@ metadataTool.controller('AnnotateController', function ($controller, $location, 
               }
             }
         });
-    });
 
-    DocumentRepo.listen([ApiResponseActions.UPDATE, ApiResponseActions.DELETE], function (response) {
-        if (response.meta.action === "UPDATE") {
-          if (response.payload && response.payload.Document && response.payload.Document.publishing === false && $scope.publishingEvents.length) {
-            $scope.publishingEvents.length = 0;
-          }
-        } else if (response.meta.action === "DELETE") {
-          $scope.publishingEvents.length = 0;
-        }
+        DocumentRepo.listen([ApiResponseActions.UPDATE, ApiResponseActions.DELETE], function (response) {
+            if (response.meta.action === "UPDATE") {
+              if (response.payload && response.payload.Document && response.payload.Document.publishing === false && $scope.publishingEvents.length) {
+                $scope.publishingEvents.length = 0;
+              }
+            } else if (response.meta.action === "DELETE") {
+              $scope.publishingEvents.length = 0;
+            }
+        });
     });
 
 });

--- a/app/filters/logTypeClassFilter.js
+++ b/app/filters/logTypeClassFilter.js
@@ -1,0 +1,23 @@
+metadataTool.filter('logTypeClass', function () {
+    return function (type) {
+      var classes = type ? "log-type-" + type.toLowerCase() : "";
+
+      switch (type) {
+        case "ALERT":
+          classes += " alert alert-danger";
+          break;
+        case "WARNING":
+          classes += " alert alert-warning";
+          break;
+        case "ATTACHMENT":
+        case "CONNECTION":
+        case "ITEM":
+        case "MESSAGE":
+          break;
+        default:
+          return "";
+      }
+
+      return classes;
+    };
+});

--- a/app/index.html
+++ b/app/index.html
@@ -238,6 +238,7 @@
 
   <!-- Filters -->
   <script src="filters/cantaloupeUrlFilter.js"></script>
+  <script src="filters/logTypeClassFilter.js"></script>
 
   <!-- Repos -->
   <script src="repo/abstractAppRepo.js"></script>

--- a/app/index.html
+++ b/app/index.html
@@ -258,6 +258,7 @@
   <script src="model/resource.js"></script>
   <script src="model/project.js"></script>
   <script src="model/metadata.js"></script>
+  <script src="model/publishingEvent.js"></script>
   <script src="model/controlledVocabulary.js"></script>
   <script src="model/projectRepository.js"></script>
   <script src="model/projectSuggestor.js"></script>

--- a/app/model/publishingEvent.js
+++ b/app/model/publishingEvent.js
@@ -1,0 +1,10 @@
+metadataTool.model("PublishingEvent", function PublishingEvent() {
+
+    return function PublishingEvent() {
+        
+        // additional model methods and variables
+
+        return this;
+    };
+
+});

--- a/app/resources/styles/sass/app.scss
+++ b/app/resources/styles/sass/app.scss
@@ -259,6 +259,46 @@ main footer {
   }
 }
 
+.panel-document-publishing.publishing-log {
+  .panel-body {
+    .log-items {
+      max-height: 100px;
+      overflow-y: auto;
+      vertical-align: super;
+
+      margin: 0px 0px 0px 0px;
+      padding-left: 0px;
+
+      .alert-warning,
+      .alert-danger {
+        font-weight: bold;
+      }
+
+      .log-item {
+        clear: both;
+
+        list-style-type: none;
+
+        padding: 2px 2px 2px 4px;
+        margin: 3px 2px;
+
+        .item-date {
+          float: right;
+          margin: 0px 10px;
+        }
+      }
+
+      .log-item:first-of-type {
+        margin-top: 0px;
+      }
+
+      .log-item:last-of-type {
+        margin-bottom: 0px;
+      }
+    }
+  }
+}
+
 .openseadragon-container {
   min-height: 675px;
 }

--- a/app/views/annotate.html
+++ b/app/views/annotate.html
@@ -28,12 +28,15 @@
     <div ng-if="action === 'view' && document.status === 'Accepted' && !document.publishing && document.getProject().repositories.length > 0" class="panel panel-warning panel-document-publishing">
         <div class="panel-heading">This document is accepted but not published.</div>
         <div class="panel-body">
-            <button class="btn btn-success" ng-click="push()">Publish</button>
+            <button class="btn btn-success" ng-click="push()" ng-disabled="cannotPublish()">Publish</button>
         </div>
     </div>
-    <div ng-if="action === 'view' && document.status === 'Accepted' && document.publishing && document.getProject().repositories.length > 0" class="panel panel-warning panel-document-publishing">
+    <div ng-if="action === 'view' && document.getProject().repositories.length > 0 && document.publishing" class="panel panel-warning panel-document-publishing publishing-log">
         <div class="panel-heading">This document is pending publication.</div>
         <div class="panel-body">
+          <ol ng-if="publishingEvents.length" class="log-items" reversed>
+            <li ng-repeat="(key, log) in publishingEvents track by key" class="log-item {{log.type | logTypeClass}}"><span class="item-message">{{log.message}}</span><span class="item-date">{{log.timestamp | date: 'medium'}}</span></li>
+          </ol>
         </div>
     </div>
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,7 +3,7 @@ module.exports = function (config) {
 
         preprocessors: {
             "app/!(node_modules)/**/*.js": "coverage",
-            '**/*.html': ['ng-html2js']
+            "app/views/**/*.html": ["ng-html2js"]
         },
 
         reporters: ['progress', 'coverage'],
@@ -11,7 +11,6 @@ module.exports = function (config) {
         basePath: './',
 
         files: [
-
             'app/config/appConfig.js',
             'app/config/apiMapping.js',
 
@@ -57,9 +56,11 @@ module.exports = function (config) {
 
             'app/directives/**/*.js',
 
+            'app/filters/**/*.js',
+
             'app/repo/**/*.js',
 
-            'app/services/**/*.js',
+            //'app/services/**/*.js',
 
             'app/model/**/*.js',
 
@@ -87,6 +88,11 @@ module.exports = function (config) {
             'karma-junit-reporter',
             'karma-ng-html2js-preprocessor'
         ],
+
+        ngHtml2JsPreprocessor: {
+            stripPrefix: "app/",
+            moduleName: "templates"
+        },
 
         coverageReporter: {
             type: "lcov",

--- a/tests/core/mocks/mockAbstractCoreRepo.js
+++ b/tests/core/mocks/mockAbstractCoreRepo.js
@@ -45,6 +45,8 @@ var mockRepo = function (repoName, $q, mockModelCtor, mockDataArray) {
 
     repo.mock(mockDataArray);
 
+    repo.scaffold = {};
+
     repo.acceptChangesPending = function () {
     };
 
@@ -150,6 +152,30 @@ var mockRepo = function (repoName, $q, mockModelCtor, mockDataArray) {
         return filteredData;
     };
 
+    repo.getScaffold = function(defaults) {
+        var updatedScaffold = repo.scaffold;
+
+        if (!defaults) defaults = {};
+        angular.extend(updatedScaffold, defaults);
+
+        return updatedScaffold;
+    };
+
+    repo.isInScaffold = function(property) {
+        var propertyFound = false;
+        var scaffoldKeys = Object.keys(repo.scaffold);
+
+        for (var i in scaffoldKeys) {
+            var scaffoldProperty = scaffoldKeys[i];
+            if (scaffoldProperty === property) {
+                propertyFound = true;
+                break;
+            }
+        }
+
+        return propertyFound;
+    };
+
     repo.getContents = function () {
         return repo.mockCopy(repo.mockedList);
     };
@@ -189,7 +215,7 @@ var mockRepo = function (repoName, $q, mockModelCtor, mockDataArray) {
         return payloadPromise($q.defer());
     };
 
-    repo.ready = function () {
+    repo.ready = function() {
         return payloadPromise($q.defer(), mockDataArray);
     };
 

--- a/tests/core/utility/coreUtility.js
+++ b/tests/core/utility/coreUtility.js
@@ -1,66 +1,157 @@
 // provide common helper methods to be used by mocks.
 
-var messagePromise = function (defer, message, messageStatus, httpStatus) {
-     defer.resolve({
-        body: angular.toJson({
-            meta: {
-                status: messageStatus ? messageStatus : 'SUCCESS',
-                message: message
-            },
-            status: httpStatus ? httpStatus : 200
-        })
-    });
-    return defer.promise;
+var buildPayloadPromiseBody = function (payload, messageStatus, httpStatus, action) {
+  var body = {
+    meta: {
+      status: messageStatus ? messageStatus : "SUCCESS",
+    },
+    payload: payload,
+    status: httpStatus ? httpStatus : 200
+  };
+
+  if (action) {
+    body.meta.action = action;
+  }
+
+  return body;
 };
 
-var valuePromise = function (defer, model) {
+var buildMessagePromiseBody = function (message, messageStatus, httpStatus, action) {
+  var body = {
+    meta: {
+      status: messageStatus ? messageStatus : "SUCCESS",
+    },
+    message: message,
+    status: httpStatus ? httpStatus : 200
+  };
+
+  if (action) {
+    body.meta.action = action;
+  }
+
+  return body;
+};
+
+var messagePromise = function (defer, message, messageStatus, httpStatus, action) {
+  defer.resolve({
+    body: angular.toJson(buildMessagePromiseBody(
+      message,
+      messageStatus,
+      httpStatus,
+      action
+    ))
+  });
+
+  return defer.promise;
+};
+
+var valuePromise = function (defer, model, type, timeout) {
+  if (type === "reject") {
+    defer.reject(model);
+  } else if (type === "notify") {
+    timeout(function () {
+      defer.notify(model);
+    }, 0);
+  } else {
     defer.resolve(model);
-    return defer.promise;
+  }
+
+  return defer.promise;
 };
 
-var payloadPromise = function (defer, payload, messageStatus, httpStatus) {
-    defer.resolve({
-        body: angular.toJson({
-            meta: {
-                status: messageStatus ? messageStatus : 'SUCCESS',
-            },
-            payload: payload,
-            status: httpStatus ? httpStatus : 200
-        })
-    });
-    return defer.promise;
+var payloadPromise = function (defer, payload, messageStatus, httpStatus, action) {
+  defer.resolve({
+    body: angular.toJson(buildPayloadPromiseBody(
+      payload,
+      messageStatus,
+      httpStatus,
+      action
+    ))
+  });
+
+  return defer.promise;
 };
 
-var dataPromise = function (defer, payload, messageStatus, httpStatus) {
-    defer.resolve({
-        data: {
-            meta: {
-                status: messageStatus ? messageStatus : 'SUCCESS',
-            },
-            payload: payload,
-            status: httpStatus ? httpStatus : 200
-        }
-    });
-    return defer.promise;
+var dataPromise = function (defer, payload, messageStatus, httpStatus, action) {
+  defer.resolve({
+    data: buildPayloadPromiseBody(
+      payload,
+      messageStatus,
+      httpStatus,
+      action
+    )
+  });
+
+  return defer.promise;
 };
 
 var rejectPromise = function (defer, payload, messageStatus, httpStatus) {
-    defer.reject({
-        body: angular.toJson({
-            meta: {
-                status: messageStatus ? messageStatus : 'INVALID',
-            },
-            payload: payload,
-            status: httpStatus ? httpStatus : 200
-        })
-    });
-    return defer.promise;
+  defer.reject({
+    body: angular.toJson(buildPayloadPromiseBody(
+      payload,
+      messageStatus ? messageStatus : "INVALID",
+      httpStatus ? httpStatus : 200,
+      action
+    ))
+  });
+
+  return defer.promise;
 };
 
-var mockParameterModel = function($q, mockModel) {
-    return function(toMock) {
-        var model = new mockModel($q);
-        model.mock(toMock);
-        return model;
-    };
+var failurePromise = function (defer, payload, messageStatus, httpStatus) {
+  defer.reject({
+    data: buildPayloadPromiseBody(
+      payload,
+      messageStatus ? messageStatus : "INVALID",
+      httpStatus ? httpStatus : 500,
+      action
+    )
+  });
+
+  return defer.promise;
+};
+
+var notifyPromise = function (timeout, defer, payload, messageStatus, httpStatus, action) {
+  timeout(function () {
+    defer.notify({
+      body: angular.toJson(buildPayloadPromiseBody(
+        payload,
+        messageStatus,
+        httpStatus,
+        action ? action : "BROADCAST"
+      ))
+    });
+  }, 0);
+
+  return defer.promise;
+};
+
+var mockParameterModel = function ($q, mockModel) {
+  return function (toMock) {
+    var model = new mockModel($q);
+    model.mock(toMock);
+    return model;
+  };
+};
+
+var mockParameterConstructor = function (mockConstructor) {
+  return function () { return mockConstructor; };
+};
+
+var mockWindow = function () {
+  return {
+    location: {
+      href: "",
+      replace: function () {}
+    }
+  };
+};
+
+var mockForms = function () {
+  return {
+    $pristine: true,
+    $untouched: true,
+    $setPristine: function (value) { this.$pristine = value; },
+    $setUntouched: function (value) { this.$untouched = value; }
+  };
 };

--- a/tests/core/utility/testUtility.js
+++ b/tests/core/utility/testUtility.js
@@ -1,0 +1,3 @@
+// provide tests or parts of tests that are commonly performed.
+
+var testUtility = {};

--- a/tests/mocks/models/mockPublishedLocation.js
+++ b/tests/mocks/models/mockPublishedLocation.js
@@ -1,0 +1,25 @@
+var dataPublishedLocation1 = {
+  id: 1,
+  repository: 1,
+  url: "http://localhost"
+};
+
+var dataPublishedLocation2 = {
+  id: 2,
+  repository: 2,
+  url: "http://localhost"
+};
+
+var dataPublishedLocation3 = {
+  id: 3,
+  repository: 3,
+  url: "http://localhost"
+};
+
+var mockPublishedLocation = function($q) {
+  var model = mockModel("PublishedLocation", $q, dataPublishedLocation1);
+
+  return model;
+};
+
+angular.module('mock.publishedLocation', []).service('PublishedLocation', mockPublishedLocation);

--- a/tests/mocks/models/mockPublishingEvent.js
+++ b/tests/mocks/models/mockPublishingEvent.js
@@ -1,0 +1,28 @@
+var dataPublishingEvent1 = {
+    id: 1,
+    type: "MESSAGE",
+    message: "message 1 - message",
+    timestamp: 1575989033
+};
+
+var dataPublishingEvent2 = {
+    id: 2,
+    type: "CONNECTION",
+    message: "message 2 - connection",
+    timestamp: 1575989034
+};
+
+var dataPublishingEvent3 = {
+    id: 3,
+    type: "ALERT",
+    message: "message 3 - alert",
+    timestamp: 1575989035
+};
+
+var mockPublishingEvent = function($q) {
+    var model = mockModel("PublishingEvent", $q, dataPublishingEvent1);
+
+    return model;
+};
+
+angular.module('mock.publishingEvent', []).service('PublishingEvent', mockPublishingEvent);

--- a/tests/mocks/services/mockWsApi.js
+++ b/tests/mocks/services/mockWsApi.js
@@ -1,70 +1,103 @@
-angular.module('mock.wsApi', []).service('WsApi', function ($q) {
-    var service = mockService($q);
-    var mapping;
+angular.module("mock.wsApi", []).service("WsApi", function ($q) {
+  var service = mockService($q);
+  var mapping;
+  var fetchResponse;
 
-    service.mockMapping = function(toMock) {
-        mapping = {};
-        for (var key in toMock) {
-            mapping[key] = toMock[key];
-        }
-    };
+  service.mockFetchResponse = function(data) {
+    if (data === null || data === undefined) {
+      fetchResponse = undefined;
+    } else {
+      // using hasOwnProperty() to support special test cases (such as checks to see if payload is undefined).
+      fetchResponse = {
+        type: data.hasOwnProperty("type") ? data.type : null,
+        payload: data.hasOwnProperty("payload") ? data.payload : {},
+        messageStatus: data.hasOwnProperty("messageStatus") ? data.messageStatus : null,
+        httpStatus: data.hasOwnProperty("httpStatus") ? data.httpStatus : null,
+        valueType: data.hasOwnProperty("valueType") ? data.valueType : null
+      };
+    }
+  };
 
-    service.fetch = function (apiReq) {
-        var payload = {};
+  service.mockMapping = function(toMock) {
+    mapping = {};
+    for (var key in toMock) {
+      mapping[key] = toMock[key];
+    }
+  };
 
-        switch (apiReq.method) {
-            case 'credentials':
-                payload = dataUser1;
-                break;
-            case 'page':
-                payload = dataDocumentPage1;
-                break;
-            case 'all':
-                switch (apiReq.controller) {
-                    case 'user':
-                        payload = dataUser1;
-                        break;
-                    case 'document':
-                        payload = dataDocument1;
-                        break;
-                    case 'cv':
-                        payload = dataControlledVocabulary1;
-                        break;
-                }
-                break;
-            case 'get':
-                switch (apiReq.controller) {
-                    case 'user':
-                        payload = dataUser1;
-                        break;
-                    case 'metadata':
-                        payload = dataMetadata1;
-                        break;
-                    case 'document':
-                        payload = dataDocument1;
-                        break;
-                }
-                break;
-            case 'update_role':
-                dataUser1.role = JSON.parse(apiReq.data).role;
-                payload = dataUser1;
-                break;
-            case 'update_annotator':
-                dataDocument1.annatator = JSON.parse(apiReq.data).annotator;
-                payload = dataDocumentRepo1;
-                break;
-        }
+  service.fetch = function (apiReq, parameters) {
+    var payload = {};
 
-        return payloadPromise($q.defer(), payload);
-    };
+    if (fetchResponse) {
+      switch (fetchResponse.type) {
+        case "message":
+          return messagePromise($q.defer(), fetchResponse.payload, fetchResponse.messageStatus, fetchResponse.httpStatus);
+        case "value":
+          return valuePromise($q.defer(), fetchResponse.payload, fetchResponse.valueType);
+        case "payload":
+          return payloadPromise($q.defer(), fetchResponse.payload, fetchResponse.messageStatus, fetchResponse.httpStatus);
+        case "data":
+          return dataPromise($q.defer(), fetchResponse.payload, fetchResponse.messageStatus, fetchResponse.httpStatus);
+        case "reject":
+          return rejectPromise($q.defer(), fetchResponse.payload, fetchResponse.messageStatus, fetchResponse.httpStatus);
+        case "failure":
+          return failurePromise($q.defer(), fetchResponse.payload, fetchResponse.messageStatus, fetchResponse.httpStatus);
+      }
+    } else {
+      switch (apiReq.method) {
+        case 'credentials':
+          payload = dataUser1;
+          break;
+        case 'page':
+          payload = dataDocumentPage1;
+          break;
+        case 'all':
+          switch (apiReq.controller) {
+            case 'user':
+              payload = dataUser1;
+              break;
+            case 'document':
+              payload = dataDocument1;
+              break;
+            case 'cv':
+              payload = dataControlledVocabulary1;
+              break;
+          }
+          break;
+        case 'get':
+          switch (apiReq.controller) {
+            case 'user':
+              payload = dataUser1;
+              break;
+            case 'metadata':
+              payload = dataMetadata1;
+              break;
+            case 'document':
+              payload = dataDocument1;
+              break;
+          }
+          break;
+        case 'update_role':
+          dataUser1.role = JSON.parse(apiReq.data).role;
+          payload = dataUser1;
+          break;
+        case 'update_annotator':
+          dataDocument1.annatator = JSON.parse(apiReq.data).annotator;
+          payload = dataDocumentRepo1;
+          break;
+      }
+    }
 
-    service.getMapping = function () {
-        return mapping;
-    };
+    return payloadPromise($q.defer(), payload);
+  };
 
-    service.listen = function (apiReq) {
-        return payloadPromise($q.defer());
-    };
+  service.getMapping = function () {
+    return mapping;
+  };
 
-    return service;
+  service.listen = function (apiReq) {
+    return payloadPromise($q.defer());
+  };
+
+  return service;
 });

--- a/tests/unit/controllers/annotateController.js
+++ b/tests/unit/controllers/annotateController.js
@@ -1,23 +1,36 @@
 describe('controller: AnnotateController', function () {
+    var $location, $q, $routeParams, $scope, $timeout, $window, AlertService, MockedUser, PublishingEvent, DocumentRepo, ProjectRepositoryRepo, WsApi, controller;
+    var $stomp;
 
-    var controller, location, q, routeParams, scope, timeout, AlertService;
+    var initializeVariables = function(settings) {
+        inject(function (_$location_, _$q_, _$routeParams_, _$timeout_, _$window_, _DocumentRepo_, _ProjectRepositoryRepo_, _WsApi_) {
+            $location = _$location_;
+            $q = _$q_;
+            $routeParams = _$routeParams_;
+            $timeout = _$timeout_;
+            $window = _$window_;
 
-    var initializeController = function (settings) {
-        inject(function ($controller, $http, $location, $q, $rootScope, $routeParams, $timeout, $window, _AlertService_, _ControlledVocabularyRepo_, _DocumentRepo_, _ModalService_, _ProjectRepositoryRepo_, _RestApi_, _ResourceRepo_, _StorageService_, _UserService_, _WsApi_) {
-            location = $location;
-            q = $q;
-            routeParams = $routeParams;
-            scope = $rootScope.$new();
-            timeout = $timeout;
+            MockedUser = new mockUser($q);
+
+            DocumentRepo = _DocumentRepo_;
+            ProjectRepositoryRepo = _ProjectRepositoryRepo_;
+            WsApi = _WsApi_;
+        });
+    };
+
+    var initializeController = function(settings) {
+        inject(function (_$controller_, _$http_, _$rootScope_, _$window_, _AlertService_, _ControlledVocabularyRepo_, _ModalService_, _PublishingEvent_, _RestApi_, _ResourceRepo_, _StorageService_, _UserService_) {
+            $scope = _$rootScope_.$new();
 
             AlertService = _AlertService_;
+            PublishingEvent = _PublishingEvent_;
 
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
             sessionStorage.token = settings && settings.token ? settings.token : "faketoken";
 
-            if (settings && settings.routeParams) {
-                if (typeof settings.routeParams == "object") {
-                    angular.extend($routeParams, settings.routeParams);
+            if (settings && settings.$routeParams) {
+                if (typeof settings.$routeParams == "object") {
+                    angular.extend($routeParams, settings.$routeParams);
                 }
             }
             else {
@@ -27,35 +40,36 @@ describe('controller: AnnotateController', function () {
                 });
             }
 
-            controller = $controller('AnnotateController', {
-                $http: $http,
+            controller = _$controller_('AnnotateController', {
+                $http: _$http_,
                 $location: $location,
                 $q: $q,
                 $routeParams: $routeParams,
-                $scope: scope,
+                $scope: $scope,
                 $timeout: $timeout,
-                $window: $window,
+                $window: _$window_,
                 AlertService: _AlertService_,
                 ControlledVocabularyRepo: _ControlledVocabularyRepo_,
-                DocumentRepo: _DocumentRepo_,
+                DocumentRepo: DocumentRepo,
                 ModalService: _ModalService_,
-                ProjectRepositoryRepo: _ProjectRepositoryRepo_,
+                ProjectRepositoryRepo: ProjectRepositoryRepo,
+                PublishingEvent: PublishingEvent,
                 RestApi: _RestApi_,
                 ResourceRepo: _ResourceRepo_,
                 StorageService: _StorageService_,
                 UserService: _UserService_,
-                WsApi: _WsApi_
+                WsApi: WsApi
             });
 
             // ensure that the isReady() is called.
-            if (!scope.$$phase) {
-                scope.$digest();
+            if (!$scope.$$phase) {
+                $scope.$digest();
             }
         });
     };
 
-    beforeEach(function () {
-        module('core');
+    beforeEach(function() {
+        module("core");
         module('metadataTool');
         module('mock.alertService');
         module('mock.controlledVocabularyRepo');
@@ -64,14 +78,22 @@ describe('controller: AnnotateController', function () {
         module('mock.modalService');
         module('mock.projectRepository');
         module('mock.projectRepositoryRepo');
+        module('mock.publishingEvent');
         module('mock.restApi');
         module('mock.resource');
         module('mock.resourceRepo');
         module('mock.storageService');
+        module("mock.user", function($provide) {
+          var User = function() {
+            return MockedUser;
+          };
+          $provide.value("User", User);
+        });
         module('mock.userService');
-        module('mock.wsApi');
+        module("mock.wsApi");
 
         installPromiseMatchers();
+        initializeVariables();
         initializeController();
     });
 
@@ -80,103 +102,128 @@ describe('controller: AnnotateController', function () {
             initializeController({ role: "ROLE_ADMIN" });
             expect(controller).toBeDefined();
         });
+
         it('should be defined for manager', function () {
             initializeController({ role: "ROLE_MANAGER" });
             expect(controller).toBeDefined();
         });
+
         it('should be defined for anonymous', function () {
             initializeController({ role: "ROLE_ANONYMOUS" });
             expect(controller).toBeDefined();
         });
     });
 
-    describe('Are the scope methods defined', function () {
+    describe('Are the $scope methods defined', function () {
         it('accept should be defined', function () {
-            expect(scope.accept).toBeDefined();
-            expect(typeof scope.accept).toEqual("function");
+            expect($scope.accept).toBeDefined();
+            expect(typeof $scope.accept).toEqual("function");
         });
+
         it('addMetadataField should be defined', function () {
-            expect(scope.addMetadataField).toBeDefined();
-            expect(typeof scope.addMetadataField).toEqual("function");
+            expect($scope.addMetadataField).toBeDefined();
+            expect(typeof $scope.addMetadataField).toEqual("function");
         });
+
         it('addSuggestion should be defined', function () {
-            expect(scope.addSuggestion).toBeDefined();
-            expect(typeof scope.addSuggestion).toEqual("function");
+            expect($scope.addSuggestion).toBeDefined();
+            expect(typeof $scope.addSuggestion).toEqual("function");
         });
+
+        it('cannotPublish should be defined', function () {
+            expect($scope.cannotPublish).toBeDefined();
+            expect(typeof $scope.cannotPublish).toEqual("function");
+        });
+
         it('delete should be defined', function () {
-            expect(scope.delete).toBeDefined();
-            expect(typeof scope.delete).toEqual("function");
+            expect($scope.delete).toBeDefined();
+            expect(typeof $scope.delete).toEqual("function");
         });
+
         it('hasFileType should be defined', function () {
-            expect(scope.hasFileType).toBeDefined();
-            expect(typeof scope.hasFileType).toEqual("function");
+            expect($scope.hasFileType).toBeDefined();
+            expect(typeof $scope.hasFileType).toEqual("function");
         });
+
         it('managerAnnotating should be defined', function () {
-            expect(scope.managerAnnotating).toBeDefined();
-            expect(typeof scope.managerAnnotating).toEqual("function");
+            expect($scope.managerAnnotating).toBeDefined();
+            expect(typeof $scope.managerAnnotating).toEqual("function");
         });
+
         it('managerReviewing should be defined', function () {
-            expect(scope.managerReviewing).toBeDefined();
-            expect(typeof scope.managerReviewing).toEqual("function");
+            expect($scope.managerReviewing).toBeDefined();
+            expect(typeof $scope.managerReviewing).toEqual("function");
         });
+
         it('getControlledVocabulary should be defined', function () {
-            expect(scope.getControlledVocabulary).toBeDefined();
-            expect(typeof scope.getControlledVocabulary).toEqual("function");
+            expect($scope.getControlledVocabulary).toBeDefined();
+            expect(typeof $scope.getControlledVocabulary).toEqual("function");
         });
+
         it('getFilesOfType should be defined', function () {
-            expect(scope.getFilesOfType).toBeDefined();
-            expect(typeof scope.getFilesOfType).toEqual("function");
+            expect($scope.getFilesOfType).toBeDefined();
+            expect(typeof $scope.getFilesOfType).toEqual("function");
         });
+
         it('getIIIFUrls should be defined', function () {
-            expect(scope.getIIIFUrls).toBeDefined();
-            expect(typeof scope.getIIIFUrls).toEqual("function");
+            expect($scope.getIIIFUrls).toBeDefined();
+            expect(typeof $scope.getIIIFUrls).toEqual("function");
         });
+
         it('getRepositoryById should be defined', function () {
-            expect(scope.getRepositoryById).toBeDefined();
-            expect(typeof scope.getRepositoryById).toEqual("function");
+            expect($scope.getRepositoryById).toBeDefined();
+            expect(typeof $scope.getRepositoryById).toEqual("function");
         });
+
         it('push should be defined', function () {
-            expect(scope.push).toBeDefined();
-            expect(typeof scope.push).toEqual("function");
+            expect($scope.push).toBeDefined();
+            expect(typeof $scope.push).toEqual("function");
         });
+
         it('removeMetadataField should be defined', function () {
-            expect(scope.removeMetadataField).toBeDefined();
-            expect(typeof scope.removeMetadataField).toEqual("function");
+            expect($scope.removeMetadataField).toBeDefined();
+            expect(typeof $scope.removeMetadataField).toEqual("function");
         });
+
         it('requiredFieldsPresent should be defined', function () {
-            expect(scope.requiredFieldsPresent).toBeDefined();
-            expect(typeof scope.requiredFieldsPresent).toEqual("function");
+            expect($scope.requiredFieldsPresent).toBeDefined();
+            expect(typeof $scope.requiredFieldsPresent).toEqual("function");
         });
+
         it('requiresCuration should be defined', function () {
-            expect(scope.requiresCuration).toBeDefined();
-            expect(typeof scope.requiresCuration).toEqual("function");
+            expect($scope.requiresCuration).toBeDefined();
+            expect(typeof $scope.requiresCuration).toEqual("function");
         });
+
         it('save should be defined', function () {
-            expect(scope.save).toBeDefined();
-            expect(typeof scope.save).toEqual("function");
+            expect($scope.save).toBeDefined();
+            expect(typeof $scope.save).toEqual("function");
         });
+
         it('submit should be defined', function () {
-            expect(scope.submit).toBeDefined();
-            expect(typeof scope.submit).toEqual("function");
+            expect($scope.submit).toBeDefined();
+            expect(typeof $scope.submit).toEqual("function");
         });
+
         it('submitRejection should be defined', function () {
-            expect(scope.submitRejection).toBeDefined();
-            expect(typeof scope.submitRejection).toEqual("function");
+            expect($scope.submitRejection).toBeDefined();
+            expect(typeof $scope.submitRejection).toEqual("function");
         });
     });
 
-    describe('Do the scope methods work as expected', function () {
+    describe('Do the $scope methods work as expected', function () {
         it('accept should submit a document as accepted', function () {
-            delete scope.document.status;
+            delete $scope.document.status;
 
-            spyOn(scope.document, 'save').and.callThrough();
+            spyOn($scope.document, 'save').and.callThrough();
 
-            scope.accept();
-            scope.$digest();
+            $scope.accept();
+            $scope.$digest();
 
-            expect(scope.document.status).toEqual("Accepted");
-            expect(scope.document.save).toHaveBeenCalled();
+            expect($scope.document.status).toEqual("Accepted");
+            expect($scope.document.save).toHaveBeenCalled();
         });
+
         it('addMetadataField should add a new field value', function () {
             var field = {
                 id: 1,
@@ -190,10 +237,11 @@ describe('controller: AnnotateController', function () {
                 }]
             };
 
-            scope.addMetadataField(field);
+            $scope.addMetadataField(field);
 
             expect(field.values.length).toEqual(2);
         });
+
         it('addSuggestion should add a suggestion', function () {
             var field = {
                 id: 1,
@@ -208,83 +256,109 @@ describe('controller: AnnotateController', function () {
             };
             var suggestion = { field: 1, value: "second" };
 
-            scope.addSuggestion(field, suggestion);
+            $scope.addSuggestion(field, suggestion);
 
             expect(field.values.length).toEqual(2);
 
             field.values[0].value = "";
             suggestion.value = "third";
 
-            scope.addSuggestion(field, suggestion);
+            $scope.addSuggestion(field, suggestion);
 
             expect(field.values[0].value).toEqual("third");
         });
+
+        it('cannotPublish should return a boolean', function () {
+          var response;
+          var document1 = new mockDocument($q);
+          var document2 = new mockDocument($q);
+          document1.publishing = false;
+          document2.publishing = true;
+
+          $scope.document = document1
+          response = $scope.cannotPublish();
+          expect(response).toBe(false);
+
+          $scope.document = document2
+          response = $scope.cannotPublish();
+          expect(response).toBe(true);
+
+          document2.publishing = "failsafe check";
+          response = $scope.cannotPublish();
+          expect(response).toBe(false);
+        });
+
         it('delete should delete a document', function () {
-            var document = new mockDocument(q);
+            var document = new mockDocument($q);
 
             spyOn(document, 'delete').and.callThrough();
 
-            scope.delete(document);
-            scope.$digest();
-            timeout.flush();
+            $scope.delete(document);
+            $scope.$digest();
+            $timeout.flush();
 
             expect(document.delete).toHaveBeenCalled();
         });
+
         it('hasFileType should return a boolean', function () {
             var response;
 
-            response = scope.hasFileType("text");
+            response = $scope.hasFileType("text");
             expect(response).toBe(true);
 
             // TODO: fixme!!
-            // response = scope.hasFileType("image");
+            // response = $scope.hasFileType("image");
             // expect(response).toBe(false);
 
-            scope.resources = [];
-            response = scope.hasFileType("text");
+            $scope.resources = [];
+            response = $scope.hasFileType("text");
             expect(response).toBe(false);
         });
+
         it('managerAnnotating should return a boolean', function () {
             var response;
 
-            routeParams.action = 'annotate';
-            response = scope.managerAnnotating();
+            $routeParams.action = 'annotate';
+            response = $scope.managerAnnotating();
 
             expect(response).toBe(true);
 
-            delete routeParams.action;
-            response = scope.managerAnnotating();
+            delete $routeParams.action;
+            response = $scope.managerAnnotating();
 
             expect(response).toBe(false);
         });
+
         it('managerReviewing should return a boolean', function () {
             var response;
 
-            routeParams.action = 'review';
-            response = scope.managerReviewing();
+            $routeParams.action = 'review';
+            response = $scope.managerReviewing();
 
             expect(response).toBe(true);
 
-            delete routeParams.action;
-            response = scope.managerReviewing();
+            delete $routeParams.action;
+            response = $scope.managerReviewing();
 
             expect(response).toBe(false);
         });
+
         it('getControlledVocabulary should return a controlled vocabulary', function () {
             var response;
 
-            response = scope.getControlledVocabulary(0);
+            response = $scope.getControlledVocabulary(0);
 
-            expect(response).toBe(scope.cv[0]);
+            expect(response).toBe($scope.cv[0]);
 
-            response = scope.getControlledVocabulary(-1);
+            response = $scope.getControlledVocabulary(-1);
 
             expect(response).toEqual([]);
         });
+
         it('getFilesOfType should return a list of files', function () {
             var response;
 
-            response = scope.getFilesOfType('text');
+            response = $scope.getFilesOfType('text');
 
             expect(response.length).toEqual(1);
             expect(response[0].name).toEqual('Resource 001');
@@ -292,83 +366,90 @@ describe('controller: AnnotateController', function () {
             expect(response[0].mimeType).toEqual('text/plain');
 
 
-            delete scope.resources;
-            response = scope.getFilesOfType('text');
+            delete $scope.resources;
+            response = $scope.getFilesOfType('text');
 
             expect(response).toEqual([]);
         });
+
         it('getIIIFUrls should return a list of URLs', function () {
             var response;
 
-            scope.document = new mockDocument(q);
+            $scope.document = new mockDocument($q);
+            $scope.document.publishedLocations = [];
 
-            response = scope.getIIIFUrls();
+            response = $scope.getIIIFUrls();
+            $scope.$digest();
 
-            expect(response).toEqual([]);
+            expect(response.length).toEqual(0);
 
-            scope.document.publishedLocations = [
-                { repository: 1, url: 'http://localhost' },
-                { repository: 2, url: 'http://localhost' },
-                { repository: 3, url: 'http://localhost' }
-            ]
+            $scope.document.publishedLocations.push(new mockPublishedLocation($q));
+            $scope.document.publishedLocations.push(new mockPublishedLocation($q));
+            $scope.document.publishedLocations.push(new mockPublishedLocation($q));
 
-            response = scope.getIIIFUrls();
+            $scope.document.publishedLocations[1].mock(dataPublishedLocation2);
+            $scope.document.publishedLocations[2].mock(dataPublishedLocation3);
+
+            response = $scope.getIIIFUrls();
+            $scope.$digest();
 
             // TODO: fixme!!
             // NOTE: sporadically fails
             // expect(response.length).toEqual(6);
         });
+
         it('getRepositoryById should return a repository', function () {
             var response;
 
-            for (var i in scope.repositories) {
-                if (scope.repositories.hasOwnProperty(i)) {
-                    response = scope.getRepositoryById(scope.repositories[i].id);
-                    expect(response).toBe(scope.repositories[i]);
+            for (var i in $scope.repositories) {
+                if ($scope.repositories.hasOwnProperty(i)) {
+                    response = $scope.getRepositoryById($scope.repositories[i].id);
+                    expect(response).toBe($scope.repositories[i]);
                 }
             }
 
-            response = scope.getRepositoryById(-1);
+            response = $scope.getRepositoryById(-1);
 
             expect(response).toBe(undefined);
         });
+
         it('push should push a document', function () {
-            scope.document = new mockDocument(q);
-            delete scope.document.status;
+            $scope.document = new mockDocument($q);
+            delete $scope.document.status;
 
-            spyOn(scope.document, 'push').and.callThrough();
-            spyOn(scope, 'openModal');
+            spyOn($scope.document, 'push').and.callThrough();
 
-            scope.push();
-            scope.$digest();
+            $scope.push();
+            $scope.$digest();
 
-            expect(scope.document.push).toHaveBeenCalled();
-            expect(scope.openModal).toHaveBeenCalled();
+            expect($scope.document.push).toHaveBeenCalled();
         });
+
         it('removeMetadataField should remove a specific metadata field', function () {
             var length;
 
-            scope.document = {
+            $scope.document = {
                 fields: {
                     a: {
                         values: ["first", "second"]
                     }
                 }
             };
-            scope.document.dirty = function () { };
-            length = scope.document.fields.a.values.length;
+            $scope.document.dirty = function () { };
+            length = $scope.document.fields.a.values.length;
 
-            spyOn(scope.document, 'dirty');
+            spyOn($scope.document, 'dirty');
 
-            scope.removeMetadataField(scope.document.fields.a, 0);
+            $scope.removeMetadataField($scope.document.fields.a, 0);
 
-            expect(scope.document.fields.a.values.length).toEqual(length - 1);
-            expect(scope.document.dirty).toHaveBeenCalled();
+            expect($scope.document.fields.a.values.length).toEqual(length - 1);
+            expect($scope.document.dirty).toHaveBeenCalled();
         });
+
         it('requiredFieldsPresent should return a boolean', function () {
             var response;
 
-            scope.document = {
+            $scope.document = {
                 fields: {
                     a: {
                         label: {
@@ -380,11 +461,11 @@ describe('controller: AnnotateController', function () {
                 }
             };
 
-            response = scope.requiredFieldsPresent();
+            response = $scope.requiredFieldsPresent();
 
             expect(response).toBe(true);
 
-            scope.document = {
+            $scope.document = {
                 fields: {
                     a: {
                         label: {
@@ -396,69 +477,126 @@ describe('controller: AnnotateController', function () {
                 }
             };
 
-            response = scope.requiredFieldsPresent();
+            response = $scope.requiredFieldsPresent();
 
             expect(response).toBe(false);
         });
+
         it('requiresCuration should submit a document as requires curation', function () {
-            delete scope.document.status;
+            delete $scope.document.status;
 
-            spyOn(scope.document, 'save').and.callThrough();
-            spyOn(location, "path");
+            spyOn($scope.document, 'save').and.callThrough();
+            spyOn($location, "path");
 
-            scope.requiresCuration();
+            $scope.requiresCuration();
 
-            expect(scope.document.status).toEqual("Requires Curation");
-            expect(scope.document.save).toHaveBeenCalled();
+            expect($scope.document.status).toEqual("Requires Curation");
+            expect($scope.document.save).toHaveBeenCalled();
         });
+
         it('save should save a document', function () {
-            scope.openModal = function () { };
-            scope.closeModal = function () { };
-            scope.document = new mockDocument(q);
+            $scope.openModal = function () { };
+            $scope.closeModal = function () { };
+            $scope.document = new mockDocument($q);
 
-            spyOn(scope, 'openModal');
-            spyOn(scope.document, 'save').and.callThrough();
+            spyOn($scope, 'openModal');
+            spyOn($scope.document, 'save').and.callThrough();
 
-            scope.save();
-            scope.$digest();
+            $scope.save();
+            $scope.$digest();
 
-            expect(scope.document.save).toHaveBeenCalled();
-            expect(scope.openModal).toHaveBeenCalled();
+            expect($scope.document.save).toHaveBeenCalled();
+            expect($scope.openModal).toHaveBeenCalled();
         });
+
         it('submit should submit a document as annotated', function () {
-            scope.openModal = function () { };
-            scope.closeModal = function () { };
-            scope.document = new mockDocument(q);
+            $scope.openModal = function () { };
+            $scope.closeModal = function () { };
+            $scope.document = new mockDocument($q);
 
-            spyOn(scope, 'openModal');
-            spyOn(scope.document, 'save').and.callThrough();
-            spyOn(location, "path");
+            spyOn($scope, 'openModal');
+            spyOn($scope.document, 'save').and.callThrough();
+            spyOn($location, "path");
 
-            scope.submit();
-            scope.$digest();
-            timeout.flush();
+            $scope.submit();
+            $scope.$digest();
+            $timeout.flush();
 
-            expect(scope.document.status).toEqual("Annotated");
-            expect(scope.document.save).toHaveBeenCalled();
-            expect(scope.openModal).toHaveBeenCalled();
-            expect(location.path).toHaveBeenCalled();
+            expect($scope.document.status).toEqual("Annotated");
+            expect($scope.document.save).toHaveBeenCalled();
+            expect($scope.openModal).toHaveBeenCalled();
+            expect($location.path).toHaveBeenCalled();
         });
+
         it('submitRejection should save a document as rejected', function () {
             var notes = "notes";
 
-            scope.document = new mockDocument(q);
+            $scope.document = new mockDocument($q);
 
-            spyOn(scope.document, 'save').and.callThrough();
+            spyOn($scope.document, 'save').and.callThrough();
             spyOn(AlertService, "add");
-            spyOn(location, "path");
+            spyOn($location, "path");
 
-            scope.submitRejection(notes);
-            scope.$digest();
-            timeout.flush();
+            $scope.submitRejection(notes);
+            $scope.$digest();
+            $timeout.flush();
 
-            expect(scope.document.status).toEqual("Rejected");
-            expect(scope.document.notes).toBe(notes);
-            expect(scope.document.save).toHaveBeenCalled();
+            expect($scope.document.status).toEqual("Rejected");
+            expect($scope.document.notes).toBe(notes);
+            expect($scope.document.save).toHaveBeenCalled();
+        });
+    });
+
+    describe("Do the listeners work as expected", function () {
+        it("Listen on '/channel/publishing/document/' should work as expected", function () {
+            var publishingEvent = new mockPublishingEvent($q);
+
+            WsApi.listen = function(path) {
+                var payload = {
+                    PublishingEvent: publishingEvent
+                };
+                return notifyPromise($timeout, $q.defer(), payload, null, null, "BROADCAST");
+            };
+
+            initializeController();
+            $scope.$digest();
+            $timeout.flush();
+
+            expect($scope.publishingEvents.length).toBe(1);
+            expect($scope.publishingEvents[0].id).toBe(publishingEvent.id);
+
+            WsApi.listen = function(path) {
+                var payload = {
+                    PublishingEvent: publishingEvent
+                };
+                return notifyPromise($timeout, $q.defer(), payload, null, null, "INVALID");
+            };
+
+            initializeController();
+            $scope.$digest();
+            $timeout.flush();
+
+            expect($scope.publishingEvents.length).toBe(0);
+
+            WsApi.listen = function(path) {
+                var payload = {
+                };
+                return notifyPromise($timeout, $q.defer(), payload, null, null, "BROADCAST");
+            };
+
+            initializeController();
+            $scope.$digest();
+            $timeout.flush();
+
+            expect($scope.publishingEvents.length).toBe(0);
+        });
+
+        it("Listen on '/channel/document' should work as expected", function () {
+            var document = new mockDocument($q);
+
+            // @todo
+            //$scope.publishingEvents.push(new mockPublishingEvent($q));
+            //expect($scope.publishingEvents.length).toBe(0);
         });
     });
 

--- a/tests/unit/filters/cantaloupeUrlFilterTest.js
+++ b/tests/unit/filters/cantaloupeUrlFilterTest.js
@@ -1,0 +1,47 @@
+describe("filter: cantaloupeUrl", function () {
+  var $scope, filter;
+
+  var initializeVariables = function() {
+  };
+
+  var initializeFilter = function(settings) {
+    inject(function (_$filter_, _$rootScope_) {
+      $scope = _$rootScope_.$new();
+
+      filter = _$filter_("cantaloupeUrl");
+    });
+  };
+
+  beforeEach(function() {
+    module("core");
+    module("metadataTool");
+
+    installPromiseMatchers();
+    initializeVariables();
+    initializeFilter();
+  });
+
+  describe("Is the filter defined", function () {
+    it("should be defined", function () {
+      expect(filter).toBeDefined();
+    });
+  });
+
+  describe("Does the filter work as expected", function () {
+    it("should return base URL on empty input", function () {
+      var result;
+
+      result = filter("");
+      expect(result).toBe(appConfig.cantaloupeService + "/info.json");
+    });
+
+    it("should return URL on valid input", function () {
+      var result;
+      var file = "example.txt";
+      var generated = btoa(file);
+
+      result = filter(file);
+      expect(result).toBe(appConfig.cantaloupeService + generated + "/info.json");
+    });
+  });
+});

--- a/tests/unit/filters/logTypeClassFilterTest.js
+++ b/tests/unit/filters/logTypeClassFilterTest.js
@@ -1,0 +1,61 @@
+describe("filter: logTypeClass", function () {
+  var $scope, filter;
+
+  var initializeVariables = function() {
+  };
+
+  var initializeFilter = function(settings) {
+    inject(function (_$filter_, _$rootScope_) {
+      $scope = _$rootScope_.$new();
+
+      filter = _$filter_("logTypeClass");
+    });
+  };
+
+  beforeEach(function() {
+    module("core");
+    module("metadataTool");
+
+    installPromiseMatchers();
+    initializeVariables();
+    initializeFilter();
+  });
+
+  describe("Is the filter defined", function () {
+    it("should be defined", function () {
+      expect(filter).toBeDefined();
+    });
+  });
+
+  describe("Does the filter work as expected", function () {
+    it("should return nothing on empty input", function () {
+      var result;
+
+      result = filter("");
+      expect(result).toBe("");
+    });
+
+    it("should return nothing on unknown input", function () {
+      var result;
+
+      result = filter("xxshould never exist xx");
+      expect(result).toBe("");
+    });
+
+    it("should return class name on valid input", function () {
+      var result;
+      var type = "ATTACHMENT";
+
+      result = filter(type);
+      expect(result).toBe("log-type-" + type.toLowerCase());
+
+      type = "ALERT";
+      result = filter(type);
+      expect(result).toContain("log-type-" + type.toLowerCase());
+
+      type = "WARNING";
+      result = filter(type);
+      expect(result).toContain("log-type-" + type.toLowerCase());
+    });
+  });
+});

--- a/tests/unit/models/publishingEvent.js
+++ b/tests/unit/models/publishingEvent.js
@@ -1,0 +1,35 @@
+describe("model: PublishingEvent", function () {
+  var $rootScope, $scope, WsApi, model;
+
+  var initializeVariables = function(settings) {
+    inject(function (_$rootScope_, _WsApi_) {
+      $rootScope = _$rootScope_;
+
+      WsApi = _WsApi_;
+    });
+  };
+
+  var initializeModel = function(settings) {
+    inject(function (PublishingEvent) {
+      $scope = $rootScope.$new();
+
+      model = angular.extend(new PublishingEvent(), dataPublishingEvent1);
+    });
+  };
+
+  beforeEach(function() {
+    module("core");
+    module("metadataTool");
+    module("mock.wsApi");
+
+    initializeVariables();
+    initializeModel();
+  });
+
+  describe("Is the model defined", function () {
+    it("should be defined", function () {
+      expect(model).toBeDefined();
+    });
+  });
+
+});


### PR DESCRIPTION
Remove the spinner.

The publishing event log is implemented using a reverse-sorted ordered list for usability and accessibility.
The numbered list is not desired, but provided for accessibility and therefore the numbers are hidden via CSS.

Implement a custom (simple/naive) filter for event-type-specific presentation.
Render the event timestamp for improved user experience.

Ensure that when publishing is off and a document update is received that the events log is cleared.

Help prevent fast clicking on publish submit button from triggering multiple publishes.
(This is still blocked by the service-end, but doing this at least prevents an annoying publish denied error.)

Significant test updates/changes.