### PR TITLE
ProjectAuthority, ProjectRepository, and ProjectSuggestor module definitions are incorrectly using Metadata as name

### DIFF
--- a/app/model/projectAuthority.js
+++ b/app/model/projectAuthority.js
@@ -1,7 +1,7 @@
-metadataTool.model("ProjectAuthority", function Metadata() {
+metadataTool.model("ProjectAuthority", function ProjectAuthority() {
 
     return function ProjectAuthority() {
-        
+
         // additional model methods and variables
 
         return this;

--- a/app/model/projectRepository.js
+++ b/app/model/projectRepository.js
@@ -1,7 +1,7 @@
-metadataTool.model("ProjectRepository", function Metadata() {
+metadataTool.model("ProjectRepository", function ProjectRepository() {
 
     return function ProjectRepository() {
-        
+
         // additional model methods and variables
 
         return this;

--- a/app/model/projectSuggestor.js
+++ b/app/model/projectSuggestor.js
@@ -1,7 +1,7 @@
-metadataTool.model("ProjectSuggestor", function Metadata() {
+metadataTool.model("ProjectSuggestor", function ProjectSuggestor() {
 
     return function ProjectSuggestor() {
-        
+
         // additional model methods and variables
 
         return this;


### PR DESCRIPTION
Fix this inconsistency in the tests.