### PR TITLE
[D01293] Can navigate to annotate for item that's already published

### DIFF
--- a/app/controllers/annotateController.js
+++ b/app/controllers/annotateController.js
@@ -1,4 +1,4 @@
-metadataTool.controller('AnnotateController', function ($controller, $location, $routeParams, $q, $scope, $timeout, AlertService, ControlledVocabularyRepo, DocumentRepo, ResourceRepo, StorageService, UserService, ProjectRepositoryRepo, WsApi) {
+metadataTool.controller('AnnotateController', function ($controller, $location, $routeParams, $q, $scope, $timeout, AlertService, ControlledVocabularyRepo, DocumentRepo, ResourceRepo, StorageService, UserService, ProjectRepositoryRepo) {
 
     angular.extend(this, $controller('AbstractController', {
         $scope: $scope

--- a/tests/core/mocks/mockAbstractCoreRepo.js
+++ b/tests/core/mocks/mockAbstractCoreRepo.js
@@ -258,8 +258,8 @@ var mockRepo = function (repoName, $q, mockModelCtor, mockDataArray) {
         var updated;
         for (var i in repo.mockedList) {
             if (repo.mockedList[i].id === model.id) {
+                angular.extend(repo.mockedList[i], model);
                 updated = repo.mockCopy(repo.mockedList[i]);
-                angular.extend(updated, model);
                 break;
             }
         }

--- a/tests/mocks/models/mockDocument.js
+++ b/tests/mocks/models/mockDocument.js
@@ -13,15 +13,15 @@ var dataDocument1 = {
     ],
     name: "Document 001",
     notes: "",
-    path: "",
+    path: "/projects/mock/mocked_1",
     project: "Project 001",
     publishedLocations: [],
-    status: ""
+    status: "Open"
 };
 
 var dataDocument2 = {
     id: 2,
-    annotator: "",
+    annotator: "Jack Daniels (123456789)",
     fields: [
         {
             id: 2,
@@ -37,10 +37,10 @@ var dataDocument2 = {
     ],
     name: "Document 002",
     notes: "",
-    path: "",
+    path: "/projects/mock/mocked_2",
     project: "Project 001",
     publishedLocations: [],
-    status: ""
+    status: "Assigned"
 };
 
 var dataDocument3 = {
@@ -49,10 +49,10 @@ var dataDocument3 = {
     fields: [],
     name: "Document 003",
     notes: "",
-    path: "",
+    path: "/projects/mock/mocked_3",
     project: "Project 002",
     publishedLocations: [],
-    status: ""
+    status: "Published"
 };
 
 var dataDocument4 = {
@@ -61,10 +61,10 @@ var dataDocument4 = {
     fields: [],
     name: "Document 004",
     notes: "",
-    path: "",
+    path: "/projects/mock/mocked_4",
     project: "Project 003",
     publishedLocations: [],
-    status: ""
+    status: "Assigned"
 };
 
 var dataDocument5 = {
@@ -73,22 +73,22 @@ var dataDocument5 = {
     fields: [],
     name: "Document 005",
     notes: "",
-    path: "",
+    path: "/projects/mock/mocked_5",
     project: "Project 003",
     publishedLocations: [],
-    status: ""
+    status: "Open"
 };
 
 var dataDocument6 = {
     id: 6,
-    annotator: "",
+    annotator: "Jack Daniels (123456789)",
     fields: [],
     name: "Document 006",
     notes: "",
-    path: "",
+    path: "/projects/mock/mocked_6",
     project: "Project 004",
     publishedLocations: [],
-    status: ""
+    status: "Requires Curation"
 };
 
 var mockDocument = function($q) {

--- a/tests/mocks/models/mockPublishedLocation.js
+++ b/tests/mocks/models/mockPublishedLocation.js
@@ -1,0 +1,25 @@
+var dataPublishedLocation1 = {
+  id: 1,
+  repository: 1,
+  url: "http://localhost"
+};
+
+var dataPublishedLocation2 = {
+  id: 2,
+  repository: 2,
+  url: "http://localhost"
+};
+
+var dataPublishedLocation3 = {
+  id: 3,
+  repository: 3,
+  url: "http://localhost"
+};
+
+var mockPublishedLocation = function($q) {
+  var model = mockModel("PublishedLocation", $q, dataPublishedLocation1);
+
+  return model;
+};
+
+angular.module('mock.publishedLocation', []).service('PublishedLocation', mockPublishedLocation);

--- a/tests/unit/controllers/annotateController.js
+++ b/tests/unit/controllers/annotateController.js
@@ -1,61 +1,73 @@
 describe('controller: AnnotateController', function () {
+    var $location, $q, $routeParams, $scope, $timeout, $window, AlertService, MockedUser, DocumentRepo, ProjectRepositoryRepo, WsApi, controller;
+    var $stomp;
 
-    var controller, location, q, routeParams, scope, timeout, AlertService;
+    var initializeVariables = function(settings) {
+        inject(function (_$location_, _$q_, _$routeParams_, _$timeout_, _$window_, _DocumentRepo_, _ProjectRepositoryRepo_, _WsApi_) {
+            $location = _$location_;
+            $q = _$q_;
+            $routeParams = _$routeParams_;
+            $timeout = _$timeout_;
+            $window = _$window_;
 
-    var initializeController = function (settings) {
-        inject(function ($controller, $http, $location, $q, $rootScope, $routeParams, $timeout, $window, _AlertService_, _ControlledVocabularyRepo_, _DocumentRepo_, _ModalService_, _ProjectRepositoryRepo_, _RestApi_, _ResourceRepo_, _StorageService_, _UserService_, _WsApi_) {
-            location = $location;
-            q = $q;
-            routeParams = $routeParams;
-            scope = $rootScope.$new();
-            timeout = $timeout;
+            MockedUser = new mockUser($q);
+
+            DocumentRepo = _DocumentRepo_;
+            ProjectRepositoryRepo = _ProjectRepositoryRepo_;
+            WsApi = _WsApi_;
+        });
+    };
+
+    var initializeController = function(settings) {
+        inject(function (_$controller_, _$http_, _$rootScope_, _$window_, _AlertService_, _ControlledVocabularyRepo_, _ModalService_, _RestApi_, _ResourceRepo_, _StorageService_, _UserService_) {
+            $scope = _$rootScope_.$new();
 
             AlertService = _AlertService_;
 
             sessionStorage.role = settings && settings.role ? settings.role : "ROLE_ADMIN";
             sessionStorage.token = settings && settings.token ? settings.token : "faketoken";
 
-            if (settings && settings.routeParams) {
-                if (typeof settings.routeParams == "object") {
-                    angular.extend($routeParams, settings.routeParams);
+            if (settings && settings.$routeParams) {
+                if (typeof settings.$routeParams == "object") {
+                    angular.extend($routeParams, settings.$routeParams);
                 }
             }
             else {
                 angular.extend($routeParams, {
                     projectKey: 'Project 001',
-                    documentKey: 'Document 001'
+                    documentKey: 'Document 002'
                 });
             }
 
-            controller = $controller('AnnotateController', {
-                $http: $http,
+            controller = _$controller_('AnnotateController', {
+                $http: _$http_,
                 $location: $location,
                 $q: $q,
                 $routeParams: $routeParams,
-                $scope: scope,
+                $scope: $scope,
                 $timeout: $timeout,
-                $window: $window,
+                $window: _$window_,
                 AlertService: _AlertService_,
                 ControlledVocabularyRepo: _ControlledVocabularyRepo_,
-                DocumentRepo: _DocumentRepo_,
+                DocumentRepo: DocumentRepo,
                 ModalService: _ModalService_,
-                ProjectRepositoryRepo: _ProjectRepositoryRepo_,
+                ProjectRepositoryRepo: ProjectRepositoryRepo,
                 RestApi: _RestApi_,
                 ResourceRepo: _ResourceRepo_,
                 StorageService: _StorageService_,
                 UserService: _UserService_,
-                WsApi: _WsApi_
+                WsApi: WsApi
             });
 
             // ensure that the isReady() is called.
-            if (!scope.$$phase) {
-                scope.$digest();
+            if (!$scope.$$phase) {
+                $scope.$digest();
             }
         });
     };
 
-    beforeEach(function () {
-        module('core');
+    beforeEach(function() {
+        module("core");
         module('metadataTool');
         module('mock.alertService');
         module('mock.controlledVocabularyRepo');
@@ -68,10 +80,17 @@ describe('controller: AnnotateController', function () {
         module('mock.resource');
         module('mock.resourceRepo');
         module('mock.storageService');
+        module("mock.user", function($provide) {
+          var User = function() {
+            return MockedUser;
+          };
+          $provide.value("User", User);
+        });
         module('mock.userService');
-        module('mock.wsApi');
+        module("mock.wsApi");
 
         installPromiseMatchers();
+        initializeVariables();
         initializeController();
     });
 
@@ -80,103 +99,123 @@ describe('controller: AnnotateController', function () {
             initializeController({ role: "ROLE_ADMIN" });
             expect(controller).toBeDefined();
         });
+
         it('should be defined for manager', function () {
             initializeController({ role: "ROLE_MANAGER" });
             expect(controller).toBeDefined();
         });
+
         it('should be defined for anonymous', function () {
             initializeController({ role: "ROLE_ANONYMOUS" });
             expect(controller).toBeDefined();
         });
     });
 
-    describe('Are the scope methods defined', function () {
+    describe('Are the $scope methods defined', function () {
         it('accept should be defined', function () {
-            expect(scope.accept).toBeDefined();
-            expect(typeof scope.accept).toEqual("function");
+            expect($scope.accept).toBeDefined();
+            expect(typeof $scope.accept).toEqual("function");
         });
+
         it('addMetadataField should be defined', function () {
-            expect(scope.addMetadataField).toBeDefined();
-            expect(typeof scope.addMetadataField).toEqual("function");
+            expect($scope.addMetadataField).toBeDefined();
+            expect(typeof $scope.addMetadataField).toEqual("function");
         });
+
         it('addSuggestion should be defined', function () {
-            expect(scope.addSuggestion).toBeDefined();
-            expect(typeof scope.addSuggestion).toEqual("function");
+            expect($scope.addSuggestion).toBeDefined();
+            expect(typeof $scope.addSuggestion).toEqual("function");
         });
+
         it('delete should be defined', function () {
-            expect(scope.delete).toBeDefined();
-            expect(typeof scope.delete).toEqual("function");
+            expect($scope.delete).toBeDefined();
+            expect(typeof $scope.delete).toEqual("function");
         });
+
         it('hasFileType should be defined', function () {
-            expect(scope.hasFileType).toBeDefined();
-            expect(typeof scope.hasFileType).toEqual("function");
+            expect($scope.hasFileType).toBeDefined();
+            expect(typeof $scope.hasFileType).toEqual("function");
         });
+
         it('managerAnnotating should be defined', function () {
-            expect(scope.managerAnnotating).toBeDefined();
-            expect(typeof scope.managerAnnotating).toEqual("function");
+            expect($scope.managerAnnotating).toBeDefined();
+            expect(typeof $scope.managerAnnotating).toEqual("function");
         });
+
         it('managerReviewing should be defined', function () {
-            expect(scope.managerReviewing).toBeDefined();
-            expect(typeof scope.managerReviewing).toEqual("function");
+            expect($scope.managerReviewing).toBeDefined();
+            expect(typeof $scope.managerReviewing).toEqual("function");
         });
+
         it('getControlledVocabulary should be defined', function () {
-            expect(scope.getControlledVocabulary).toBeDefined();
-            expect(typeof scope.getControlledVocabulary).toEqual("function");
+            expect($scope.getControlledVocabulary).toBeDefined();
+            expect(typeof $scope.getControlledVocabulary).toEqual("function");
         });
+
         it('getFilesOfType should be defined', function () {
-            expect(scope.getFilesOfType).toBeDefined();
-            expect(typeof scope.getFilesOfType).toEqual("function");
+            expect($scope.getFilesOfType).toBeDefined();
+            expect(typeof $scope.getFilesOfType).toEqual("function");
         });
+
         it('getIIIFUrls should be defined', function () {
-            expect(scope.getIIIFUrls).toBeDefined();
-            expect(typeof scope.getIIIFUrls).toEqual("function");
+            expect($scope.getIIIFUrls).toBeDefined();
+            expect(typeof $scope.getIIIFUrls).toEqual("function");
         });
+
         it('getRepositoryById should be defined', function () {
-            expect(scope.getRepositoryById).toBeDefined();
-            expect(typeof scope.getRepositoryById).toEqual("function");
+            expect($scope.getRepositoryById).toBeDefined();
+            expect(typeof $scope.getRepositoryById).toEqual("function");
         });
+
         it('push should be defined', function () {
-            expect(scope.push).toBeDefined();
-            expect(typeof scope.push).toEqual("function");
+            expect($scope.push).toBeDefined();
+            expect(typeof $scope.push).toEqual("function");
         });
+
         it('removeMetadataField should be defined', function () {
-            expect(scope.removeMetadataField).toBeDefined();
-            expect(typeof scope.removeMetadataField).toEqual("function");
+            expect($scope.removeMetadataField).toBeDefined();
+            expect(typeof $scope.removeMetadataField).toEqual("function");
         });
+
         it('requiredFieldsPresent should be defined', function () {
-            expect(scope.requiredFieldsPresent).toBeDefined();
-            expect(typeof scope.requiredFieldsPresent).toEqual("function");
+            expect($scope.requiredFieldsPresent).toBeDefined();
+            expect(typeof $scope.requiredFieldsPresent).toEqual("function");
         });
+
         it('requiresCuration should be defined', function () {
-            expect(scope.requiresCuration).toBeDefined();
-            expect(typeof scope.requiresCuration).toEqual("function");
+            expect($scope.requiresCuration).toBeDefined();
+            expect(typeof $scope.requiresCuration).toEqual("function");
         });
+
         it('save should be defined', function () {
-            expect(scope.save).toBeDefined();
-            expect(typeof scope.save).toEqual("function");
+            expect($scope.save).toBeDefined();
+            expect(typeof $scope.save).toEqual("function");
         });
+
         it('submit should be defined', function () {
-            expect(scope.submit).toBeDefined();
-            expect(typeof scope.submit).toEqual("function");
+            expect($scope.submit).toBeDefined();
+            expect(typeof $scope.submit).toEqual("function");
         });
+
         it('submitRejection should be defined', function () {
-            expect(scope.submitRejection).toBeDefined();
-            expect(typeof scope.submitRejection).toEqual("function");
+            expect($scope.submitRejection).toBeDefined();
+            expect(typeof $scope.submitRejection).toEqual("function");
         });
     });
 
-    describe('Do the scope methods work as expected', function () {
+    describe('Do the $scope methods work as expected', function () {
         it('accept should submit a document as accepted', function () {
-            delete scope.document.status;
+            delete $scope.document.status;
 
-            spyOn(scope.document, 'save').and.callThrough();
+            spyOn($scope.document, 'save').and.callThrough();
 
-            scope.accept();
-            scope.$digest();
+            $scope.accept();
+            $scope.$digest();
 
-            expect(scope.document.status).toEqual("Accepted");
-            expect(scope.document.save).toHaveBeenCalled();
+            expect($scope.document.status).toEqual("Accepted");
+            expect($scope.document.save).toHaveBeenCalled();
         });
+
         it('addMetadataField should add a new field value', function () {
             var field = {
                 id: 1,
@@ -190,10 +229,11 @@ describe('controller: AnnotateController', function () {
                 }]
             };
 
-            scope.addMetadataField(field);
+            $scope.addMetadataField(field);
 
             expect(field.values.length).toEqual(2);
         });
+
         it('addSuggestion should add a suggestion', function () {
             var field = {
                 id: 1,
@@ -208,83 +248,89 @@ describe('controller: AnnotateController', function () {
             };
             var suggestion = { field: 1, value: "second" };
 
-            scope.addSuggestion(field, suggestion);
+            $scope.addSuggestion(field, suggestion);
 
             expect(field.values.length).toEqual(2);
 
             field.values[0].value = "";
             suggestion.value = "third";
 
-            scope.addSuggestion(field, suggestion);
+            $scope.addSuggestion(field, suggestion);
 
             expect(field.values[0].value).toEqual("third");
         });
+
         it('delete should delete a document', function () {
-            var document = new mockDocument(q);
+            var document = $scope.document;
 
             spyOn(document, 'delete').and.callThrough();
 
-            scope.delete(document);
-            scope.$digest();
-            timeout.flush();
+            $scope.delete(document);
+            $scope.$digest();
+            $timeout.flush();
 
             expect(document.delete).toHaveBeenCalled();
         });
+
         it('hasFileType should return a boolean', function () {
             var response;
 
-            response = scope.hasFileType("text");
+            response = $scope.hasFileType("text");
             expect(response).toBe(true);
 
             // TODO: fixme!!
-            // response = scope.hasFileType("image");
+            // response = $scope.hasFileType("image");
             // expect(response).toBe(false);
 
-            scope.resources = [];
-            response = scope.hasFileType("text");
+            $scope.resources = [];
+            response = $scope.hasFileType("text");
             expect(response).toBe(false);
         });
+
         it('managerAnnotating should return a boolean', function () {
             var response;
 
-            routeParams.action = 'annotate';
-            response = scope.managerAnnotating();
+            $routeParams.action = 'annotate';
+            response = $scope.managerAnnotating();
 
             expect(response).toBe(true);
 
-            delete routeParams.action;
-            response = scope.managerAnnotating();
+            delete $routeParams.action;
+            response = $scope.managerAnnotating();
 
             expect(response).toBe(false);
         });
+
         it('managerReviewing should return a boolean', function () {
             var response;
 
-            routeParams.action = 'review';
-            response = scope.managerReviewing();
+            $routeParams.action = 'review';
+            response = $scope.managerReviewing();
 
             expect(response).toBe(true);
 
-            delete routeParams.action;
-            response = scope.managerReviewing();
+            delete $routeParams.action;
+            response = $scope.managerReviewing();
 
             expect(response).toBe(false);
         });
+
         it('getControlledVocabulary should return a controlled vocabulary', function () {
             var response;
 
-            response = scope.getControlledVocabulary(0);
+            response = $scope.getControlledVocabulary(0);
 
-            expect(response).toBe(scope.cv[0]);
+            expect(response).toBe($scope.cv[0]);
 
-            response = scope.getControlledVocabulary(-1);
+            response = $scope.getControlledVocabulary(-1);
 
             expect(response).toEqual([]);
         });
+
         it('getFilesOfType should return a list of files', function () {
             var response;
 
-            response = scope.getFilesOfType('text');
+            response = $scope.getFilesOfType('text');
 
             expect(response.length).toEqual(1);
             expect(response[0].name).toEqual('Resource 001');
@@ -292,173 +338,221 @@ describe('controller: AnnotateController', function () {
             expect(response[0].mimeType).toEqual('text/plain');
 
 
-            delete scope.resources;
-            response = scope.getFilesOfType('text');
+            delete $scope.resources;
+            response = $scope.getFilesOfType('text');
 
             expect(response).toEqual([]);
         });
+
         it('getIIIFUrls should return a list of URLs', function () {
             var response;
 
-            scope.document = new mockDocument(q);
+            $scope.document = new mockDocument($q);
+            $scope.document.publishedLocations = [];
 
-            response = scope.getIIIFUrls();
+            response = $scope.getIIIFUrls();
+            $scope.$digest();
 
-            expect(response).toEqual([]);
+            expect(response.length).toEqual(0);
 
-            scope.document.publishedLocations = [
-                { repository: 1, url: 'http://localhost' },
-                { repository: 2, url: 'http://localhost' },
-                { repository: 3, url: 'http://localhost' }
-            ]
+            $scope.document.publishedLocations.push(new mockPublishedLocation($q));
+            $scope.document.publishedLocations.push(new mockPublishedLocation($q));
+            $scope.document.publishedLocations.push(new mockPublishedLocation($q));
 
-            response = scope.getIIIFUrls();
+            $scope.document.publishedLocations[1].mock(dataPublishedLocation2);
+            $scope.document.publishedLocations[2].mock(dataPublishedLocation3);
+
+            response = $scope.getIIIFUrls();
+            $scope.$digest();
 
             // TODO: fixme!!
             // NOTE: sporadically fails
             // expect(response.length).toEqual(6);
         });
+
         it('getRepositoryById should return a repository', function () {
             var response;
 
-            for (var i in scope.repositories) {
-                if (scope.repositories.hasOwnProperty(i)) {
-                    response = scope.getRepositoryById(scope.repositories[i].id);
-                    expect(response).toBe(scope.repositories[i]);
+            for (var i in $scope.repositories) {
+                if ($scope.repositories.hasOwnProperty(i)) {
+                    response = $scope.getRepositoryById($scope.repositories[i].id);
+                    expect(response).toBe($scope.repositories[i]);
                 }
             }
 
-            response = scope.getRepositoryById(-1);
+            response = $scope.getRepositoryById(-1);
 
             expect(response).toBe(undefined);
         });
+
         it('push should push a document', function () {
-            scope.document = new mockDocument(q);
-            delete scope.document.status;
+            delete $scope.document.status;
 
-            spyOn(scope.document, 'push').and.callThrough();
-            spyOn(scope, 'openModal');
+            spyOn($scope.document, 'push').and.callThrough();
 
-            scope.push();
-            scope.$digest();
+            $scope.push();
+            $scope.$digest();
 
-            expect(scope.document.push).toHaveBeenCalled();
-            expect(scope.openModal).toHaveBeenCalled();
+            expect($scope.document.push).toHaveBeenCalled();
         });
+
         it('removeMetadataField should remove a specific metadata field', function () {
             var length;
 
-            scope.document = {
-                fields: {
-                    a: {
-                        values: ["first", "second"]
-                    }
+            $scope.document.fields = {
+                a: {
+                    values: ["first", "second"]
                 }
             };
-            scope.document.dirty = function () { };
-            length = scope.document.fields.a.values.length;
+            $scope.document.dirty = function () { };
+            length = $scope.document.fields.a.values.length;
 
-            spyOn(scope.document, 'dirty');
+            spyOn($scope.document, 'dirty');
 
-            scope.removeMetadataField(scope.document.fields.a, 0);
+            $scope.removeMetadataField($scope.document.fields.a, 0);
 
-            expect(scope.document.fields.a.values.length).toEqual(length - 1);
-            expect(scope.document.dirty).toHaveBeenCalled();
+            expect($scope.document.fields.a.values.length).toEqual(length - 1);
+            expect($scope.document.dirty).toHaveBeenCalled();
         });
+
         it('requiredFieldsPresent should return a boolean', function () {
             var response;
 
-            scope.document = {
-                fields: {
-                    a: {
-                        label: {
-                            profile: {
-                                required: true
-                            }
+            $scope.document.fields = {
+                a: {
+                    label: {
+                        profile: {
+                            required: true
                         }
                     }
                 }
             };
 
-            response = scope.requiredFieldsPresent();
+            response = $scope.requiredFieldsPresent();
 
             expect(response).toBe(true);
 
-            scope.document = {
-                fields: {
-                    a: {
-                        label: {
-                            profile: {
-                                required: false
-                            }
+            $scope.document.mock(dataDocument2);
+            $scope.document.fields = {
+                a: {
+                    label: {
+                        profile: {
+                            required: false
                         }
                     }
                 }
             };
 
-            response = scope.requiredFieldsPresent();
+            response = $scope.requiredFieldsPresent();
 
             expect(response).toBe(false);
         });
+
         it('requiresCuration should submit a document as requires curation', function () {
-            delete scope.document.status;
+            delete $scope.document.status;
 
-            spyOn(scope.document, 'save').and.callThrough();
-            spyOn(location, "path");
+            spyOn($scope.document, 'save').and.callThrough();
+            spyOn($location, "path");
 
-            scope.requiresCuration();
+            $scope.requiresCuration();
 
-            expect(scope.document.status).toEqual("Requires Curation");
-            expect(scope.document.save).toHaveBeenCalled();
+            expect($scope.document.status).toEqual("Requires Curation");
+            expect($scope.document.save).toHaveBeenCalled();
         });
+
         it('save should save a document', function () {
-            scope.openModal = function () { };
-            scope.closeModal = function () { };
-            scope.document = new mockDocument(q);
+            $scope.openModal = function () { };
+            $scope.closeModal = function () { };
 
-            spyOn(scope, 'openModal');
-            spyOn(scope.document, 'save').and.callThrough();
+            spyOn($scope, 'openModal');
+            spyOn($scope.document, 'save').and.callThrough();
 
-            scope.save();
-            scope.$digest();
+            $scope.save();
+            $scope.$digest();
 
-            expect(scope.document.save).toHaveBeenCalled();
-            expect(scope.openModal).toHaveBeenCalled();
+            expect($scope.document.save).toHaveBeenCalled();
+            expect($scope.openModal).toHaveBeenCalled();
         });
+
         it('submit should submit a document as annotated', function () {
-            scope.openModal = function () { };
-            scope.closeModal = function () { };
-            scope.document = new mockDocument(q);
+            $scope.openModal = function () { };
+            $scope.closeModal = function () { };
 
-            spyOn(scope, 'openModal');
-            spyOn(scope.document, 'save').and.callThrough();
-            spyOn(location, "path");
+            spyOn($scope, 'openModal');
+            spyOn($scope.document, 'save').and.callThrough();
+            spyOn($location, "path");
 
-            scope.submit();
-            scope.$digest();
-            timeout.flush();
+            $scope.submit();
+            $scope.$digest();
+            $timeout.flush();
 
-            expect(scope.document.status).toEqual("Annotated");
-            expect(scope.document.save).toHaveBeenCalled();
-            expect(scope.openModal).toHaveBeenCalled();
-            expect(location.path).toHaveBeenCalled();
+            expect($scope.document.status).toEqual("Annotated");
+            expect($scope.document.save).toHaveBeenCalled();
+            expect($scope.openModal).toHaveBeenCalled();
+            expect($location.path).toHaveBeenCalled();
         });
+
         it('submitRejection should save a document as rejected', function () {
             var notes = "notes";
 
-            scope.document = new mockDocument(q);
-
-            spyOn(scope.document, 'save').and.callThrough();
+            spyOn($scope.document, 'save').and.callThrough();
             spyOn(AlertService, "add");
-            spyOn(location, "path");
+            spyOn($location, "path");
 
-            scope.submitRejection(notes);
-            scope.$digest();
-            timeout.flush();
+            $scope.submitRejection(notes);
+            $scope.$digest();
+            $timeout.flush();
 
-            expect(scope.document.status).toEqual("Rejected");
-            expect(scope.document.notes).toBe(notes);
-            expect(scope.document.save).toHaveBeenCalled();
+            expect($scope.document.status).toEqual("Rejected");
+            expect($scope.document.notes).toBe(notes);
+            expect($scope.document.save).toHaveBeenCalled();
+        });
+    });
+
+    describe('Is the controller initialized as expected', function () {
+        it('should be process field.values', function () {
+            var document = new mockDocument($q);
+            document.mock(dataDocument2);
+            document.fields[0].values = [];
+
+            DocumentRepo.update(document);
+            $scope.$digest();
+
+            initializeController();
+            expect(controller).toBeDefined();
+        });
+
+        it('should be redirect on disallowed document statuses', function () {
+            var originalPath = $location.path;
+            spyOn($location, "path").and.callThrough();
+
+            initializeController();
+            expect(controller).toBeDefined();
+            expect($location.path).not.toHaveBeenCalled();
+
+            $location.path = originalPath;
+            spyOn($location, "path").and.callThrough();
+
+            initializeController({
+                $routeParams: {
+                  projectKey: 'Project 001',
+                  documentKey: 'Document 001'
+                }
+            });
+            expect(controller).toBeDefined();
+            expect($location.path).toHaveBeenCalled();
+
+            $location.path = originalPath;
+            spyOn($location, "path").and.callThrough();
+
+            initializeController({
+                $routeParams: {
+                  projectKey: 'Project 002',
+                  documentKey: 'Document 003'
+                }
+            });
+            expect(controller).toBeDefined();
+            expect($location.path).toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
Redirect to appropriate "/view" path when in an invalid status for annotation.

The console will show unsubscribe() calls after the subscribe() calls after this redirect.
These calls make it appear as if the listeners are unsubscribed when they are not.
It seems that the order of the calls (as presented in the console log) can be safely ignored.