### PR TITLE
[B03983][MERGE][FIX] Fix merge regression between publishing log and annotate restriction branches

### DIFF
--- a/app/controllers/annotateController.js
+++ b/app/controllers/annotateController.js
@@ -41,8 +41,8 @@ metadataTool.controller('AnnotateController', function ($controller, $location, 
                     var setting = settings[i];
                     if (setting.key === key) {
                         return setting;
-            }
-        }
+                    }
+                }
             }
         };
 
@@ -218,46 +218,41 @@ metadataTool.controller('AnnotateController', function ($controller, $location, 
             }
         };
 
-        if ($scope.document.status === "Assigned") {
-            // Add all listeners and logic here to avoid processing during the redirect case.
+        if ($routeParams.action !== "view" && $scope.document.status !== "Assigned") {
+            $scope.action = "view";
+        }
 
-            for (var k in $scope.document.fields) {
-                var field = $scope.document.fields[k];
-                if (field.values.length === 0) {
-                    field.values.push(emptyFieldValue(field));
+        for (var k in $scope.document.fields) {
+            var field = $scope.document.fields[k];
+            if (field.values.length === 0) {
+                field.values.push(emptyFieldValue(field));
+            }
+        }
+
+        $scope.document.getSuggestions().then(function (response) {
+            var payload = angular.fromJson(response.body).payload;
+            $scope.suggestions = payload["ArrayList<Suggestion>"] !== undefined ? payload["ArrayList<Suggestion>"] : payload.ArrayList;
+        });
+
+        WsApi.listen("/channel/publishing/document/" + $scope.document.id).then(null, null, function (rawResponse) {
+            var response = angular.fromJson(rawResponse.body);
+
+            if (response.meta.action === "BROADCAST") {
+                if (response.payload.PublishingEvent) {
+                    $scope.publishingEvents.unshift(response.payload.PublishingEvent);
                 }
             }
+        });
 
-            $scope.document.getSuggestions().then(function (response) {
-                var payload = angular.fromJson(response.body).payload;
-                $scope.suggestions = payload["ArrayList<Suggestion>"] !== undefined ? payload["ArrayList<Suggestion>"] : payload.ArrayList;
-            });
-
-            WsApi.listen("/channel/publishing/document/" + $scope.document.id).then(null, null, function (rawResponse) {
-                var response = angular.fromJson(rawResponse.body);
-
-                if (response.meta.action === "BROADCAST") {
-                  if (response.payload.PublishingEvent) {
-                    $scope.publishingEvents.unshift(response.payload.PublishingEvent);
-                  }
-                }
-            });
-
-            DocumentRepo.listen([ApiResponseActions.UPDATE, ApiResponseActions.DELETE], function (response) {
-                if (response.meta.action === "UPDATE") {
-                  if (response.payload && response.payload.Document && response.payload.Document.publishing === false && $scope.publishingEvents.length) {
+        DocumentRepo.listen([ApiResponseActions.UPDATE, ApiResponseActions.DELETE], function (response) {
+            if (response.meta.action === "UPDATE") {
+                if (response.payload && response.payload.Document && response.payload.Document.publishing === false && $scope.publishingEvents.length) {
                     $scope.publishingEvents.length = 0;
-                  }
-                } else if (response.meta.action === "DELETE") {
-                  $scope.publishingEvents.length = 0;
                 }
-            });
-        } else {
-            var url = $location.path().split("/");
-            url.length--;
-            url.push("view");
-            $location.path(url.join("/"));
-        }
+            } else if (response.meta.action === "DELETE") {
+                $scope.publishingEvents.length = 0;
+            }
+        });
     });
 
 });

--- a/tests/unit/controllers/annotateController.js
+++ b/tests/unit/controllers/annotateController.js
@@ -36,7 +36,8 @@ describe('controller: AnnotateController', function () {
             else {
                 angular.extend($routeParams, {
                     projectKey: 'Project 001',
-                    documentKey: 'Document 002'
+                    documentKey: 'Document 002',
+                    action: "annotate"
                 });
             }
 
@@ -604,16 +605,10 @@ describe('controller: AnnotateController', function () {
             expect(controller).toBeDefined();
         });
 
-        it('should be redirect on disallowed document statuses', function () {
-            var originalPath = $location.path;
-            spyOn($location, "path").and.callThrough();
-
+        it('should be view action on disallowed document statuses', function () {
             initializeController();
             expect(controller).toBeDefined();
-            expect($location.path).not.toHaveBeenCalled();
-
-            $location.path = originalPath;
-            spyOn($location, "path").and.callThrough();
+            expect($scope.action).toBe("annotate");
 
             initializeController({
                 $routeParams: {
@@ -622,10 +617,7 @@ describe('controller: AnnotateController', function () {
                 }
             });
             expect(controller).toBeDefined();
-            expect($location.path).toHaveBeenCalled();
-
-            $location.path = originalPath;
-            spyOn($location, "path").and.callThrough();
+            expect($scope.action).toBe("view");
 
             initializeController({
                 $routeParams: {
@@ -634,7 +626,7 @@ describe('controller: AnnotateController', function () {
                 }
             });
             expect(controller).toBeDefined();
-            expect($location.path).toHaveBeenCalled();
+            expect($scope.action).toBe("view");
         });
     });
 


### PR DESCRIPTION
The controller for the "view" seems to be the same controller for "annotate".
The resulting logic in annotation access control checks prevents the publishing log listeners from being assigned.

It turns out that the path can be changed via assigning `$scope.action`.
The `$location.path()` redirect can be replaced with a `$scope.action`, simplifying the code.

Fix whitespace issues resulting from the merge.
