### PR TITLE
[B03986] Create Field Profile modal improvements

### DIFF
--- a/app/controllers/projectController.js
+++ b/app/controllers/projectController.js
@@ -1,4 +1,4 @@
-metadataTool.controller('ProjectController', function ($q, $controller, $scope, AlertService, UserService, ProjectRepo, ProjectRepositoryRepo, ProjectAuthorityRepo, ProjectSuggestorRepo, MetadataRepo) {
+metadataTool.controller('ProjectController', function ($controller, $scope, AlertService, UserService, ProjectRepo, ProjectRepositoryRepo, ProjectAuthorityRepo, ProjectSuggestorRepo, MetadataRepo) {
 
     angular.extend(this, $controller('AbstractController', {$scope: $scope}));
 

--- a/app/controllers/projectController.js
+++ b/app/controllers/projectController.js
@@ -1,4 +1,4 @@
-metadataTool.controller('ProjectController', function ($controller, $scope, AlertService, UserService, ProjectRepo, ProjectRepositoryRepo, ProjectAuthorityRepo, ProjectSuggestorRepo, MetadataRepo) {
+metadataTool.controller('ProjectController', function ($q, $controller, $scope, AlertService, UserService, ProjectRepo, ProjectRepositoryRepo, ProjectAuthorityRepo, ProjectSuggestorRepo, MetadataRepo) {
 
     angular.extend(this, $controller('AbstractController', {$scope: $scope}));
 
@@ -19,8 +19,6 @@ metadataTool.controller('ProjectController', function ($controller, $scope, Aler
     $scope.isEditing = false;
     $scope.isSyncing = false;
 
-    $scope.displayResponse = {"status":null,"message":null};
-
     $scope.setFieldProfileForm = function(profile) {
         if (profile) {
             $scope.fieldProfileFormTitle = "Editing "+profile.gloss;
@@ -38,11 +36,9 @@ metadataTool.controller('ProjectController', function ($controller, $scope, Aler
         }
     };
 
-    $scope.setFieldProfileForm();
-
     UserService.userReady().then(function() {
 
-    if($scope.isAdmin() || $scope.isManager()) {
+      if ($scope.isAdmin() || $scope.isManager()) {
         $scope.projectServices.repositories = ProjectRepositoryRepo.getAll();
         $scope.projectServices.authorities = ProjectAuthorityRepo.getAll();
         $scope.projectServices.suggestors = ProjectSuggestorRepo.getAll();
@@ -92,7 +88,35 @@ metadataTool.controller('ProjectController', function ($controller, $scope, Aler
             });
         };
 
-        $scope.projectHasService = function(project, serviceType, index) {
+        $scope.resetFieldProfileForm = function () {
+            $scope.closeModal();
+            $scope.setFieldProfileForm();
+
+            if ($scope.project) {
+              var facets = [
+                "project/" + $scope.project.id + "/add-field-profile",
+                "project/" + $scope.project.id + "/update-field-profile"
+              ];
+
+              var alerts;
+              var j;
+              for (var i in facets) {
+                alerts = AlertService.get(facets[i]);
+
+                if (alerts) {
+                  for (j in alerts.list) {
+                    AlertService.remove(alerts.list[j]);
+                  }
+                }
+              }
+            }
+        };
+
+        $scope.onCancelFieldProfileForm = function () {
+            $scope.resetFieldProfileForm();
+        };
+
+        $scope.projectHasService = function (project, serviceType, index) {
             var hasService = false;
 
             angular.forEach(project[serviceType], function (projectService) {
@@ -106,7 +130,7 @@ metadataTool.controller('ProjectController', function ($controller, $scope, Aler
 
         var manageProject = function(method,project) {
             return ProjectRepo[method](project).then(function() {
-                $scope.closeModal();
+                $scope.resetFieldProfileForm();
             });
         };
 
@@ -118,23 +142,17 @@ metadataTool.controller('ProjectController', function ($controller, $scope, Aler
             var success = false;
             if ($scope.isEditing) {
                 ProjectRepo.updateFieldProfile(projectId, profile, labels).then(function(data) {
-                    var response = processRestResponse(data, 'displayResponse');
-                    if (response) {
+                    if (processRestResponse(data)) {
                         $scope.setFieldProfileForm();
                     }
                 });
             } else {
                 ProjectRepo.addFieldProfile(projectId, profile, labels).then(function(data) {
-                    var response = processRestResponse(data, 'displayResponse');
-                    if (response) {
+                    if (processRestResponse(data)) {
                         $scope.setFieldProfileForm();
                     }
                 });
             }
-        };
-
-        $scope.clearDisplayResponse = function() {
-            $scope.displayResponse = {"status":null,"message":null};
         };
 
         /*
@@ -145,21 +163,12 @@ metadataTool.controller('ProjectController', function ($controller, $scope, Aler
          *
          */
 
-        var processRestResponse = function(data, displayModelName) {
+        var processRestResponse = function (data) {
             var response = angular.fromJson(data.body);
-            var result = null;
-            if (response.status == 500) {
-                $scope[displayModelName].status = false;
-                $scope[displayModelName].message = response.error;
-            } else if (response.meta.status == "ERROR") {
-                $scope[displayModelName].status = false;
-                $scope[displayModelName].message = response.meta.message;
-            } else {
-                $scope[displayModelName].status = true;
-                $scope[displayModelName].message = response.meta.message;
-                result = response;
+            if (response.status === 500 || response.meta.status === "ERROR") {
+                return false;
             }
-            return result;
+            return true;
         };
 
         $scope.syncDocuments = function (project) {
@@ -169,11 +178,13 @@ metadataTool.controller('ProjectController', function ($controller, $scope, Aler
                 if (response.meta.status === "SUCCESS") {
                   AlertService.add(response.meta, "app/projects");
                 }
-                $scope.closeModal();
+                $scope.resetFieldProfileForm();
                 $scope.isSyncing = false;
             });
         };
-    }
-  });
+
+        $scope.resetFieldProfileForm();
+      }
+    });
 
 });

--- a/app/views/modals/projectFieldProfiles.html
+++ b/app/views/modals/projectFieldProfiles.html
@@ -1,5 +1,5 @@
 <div class="modal-header {{attr.modalHeaderClass}}">
-  <button type="button" class="close modal-close" aria-label="Close" ng-click="closeModal()"><span aria-hidden="true">&times;</span></button>
+  <button type="button" class="close modal-close" aria-label="Close" ng-click="onCancelFieldProfileForm()"><span aria-hidden="true">&times;</span></button>
   <h4 class="modal-title">Edit Field Profiles for {{project.name}}</h4>
 </div>
 <div class="modal-body">
@@ -16,7 +16,7 @@
     </div>
     <div class="col-md-6">
       <h4>{{fieldProfileFormTitle}}</h4>
-      <div ng-if="displayResponse.message" class="alert alert-wrapper" ng-class="{'alert-success':displayResponse.status,'alert-danger':!displayResponse.status}" ng-click="clearDisplayResponse()" role="alert">{{displayResponse.message}}</div>
+      <alerts seconds="60" channels="project/{{project.id}}/add-field-profile,project/{{project.id}}/update-field-profile" types="SUCCESS,WARNING,ERROR" exclusive></alerts>
       <form name="manageProfile" novalidate>
         <div class="form-group">
           <label>Gloss</label>
@@ -26,7 +26,7 @@
           <label>Label</label>
           <input ng-if="!isEditing" class="form-control" type="text" name="label" ng-model="managingLabels[0].name" />
           <input ng-if="isEditing" class="form-control" type="text" name="label" ng-model="label.name" ng-repeat="label in managingLabels" />
-        </div>        
+        </div>
         <div class="form-group">
           <label>Default Value</label>
           <input class="form-control" type="text" name="defaultValue" ng-model="managingProfile.defaultValue" />
@@ -87,6 +87,7 @@
             </label>
           </div>
         </div>
+        <button type="button" class="btn btn-default" ng-click="onCancelFieldProfileForm()">Cancel</button>
         <button type="button" class="btn btn-success" ng-click="updateFieldProfile(project.id, managingProfile, managingLabels)">{{isEditing ? 'Update':'Create'}} Profile</button>
         <button ng-if="isEditing" type="button" class="btn btn-warning" ng-click="setFieldProfileForm()">Cancel Edit</button>
       </form>

--- a/tests/mocks/models/mockAlert.js
+++ b/tests/mocks/models/mockAlert.js
@@ -1,0 +1,43 @@
+var dataAlert1 = {
+    id: 1,
+    channel: "unassigned",
+    class: "info",
+    fade: false,
+    fixed: false,
+    message: "Generic Alert",
+    remove: false,
+    time: 1576249725726,
+    type: "UNKNOWN"
+};
+
+var dataAlert2 = {
+    id: 2,
+    channel: "project/1/add-field-profile",
+    class: "danger",
+    fade: true,
+    fixed: false,
+    message: "(500) No message available",
+    remove: true,
+    time: 1576249725746,
+    type: "ERROR"
+};
+
+var dataAlert3 = {
+    id: 3,
+    channel: "project/1/update-field-profile",
+    class: "success",
+    fade: false,
+    fixed: true,
+    message: "Field Profile updated",
+    remove: true,
+    time: 1576249914577,
+    type: "SUCCESS"
+};
+
+var mockAlert = function($q) {
+    var model = mockModel("Alert", $q, dataAlert1);
+
+    return model;
+};
+
+angular.module('mock.alert', []).service('Alert', mockAlert);


### PR DESCRIPTION
Handle alerts in the model.
Clear the alerts on close.
Provide a cancel button.
Treat the cancel button and X (close) button as the same.

Validation has not been implemented at this time because there appears to be a lot of significant design changes that would be necessary to utilize the weaver validation.

While I would prefer to have the buttons in the button section of the model and the messages across the top, these changes were avoided to ensure consistency in existing design.